### PR TITLE
Feature static assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,19 +92,6 @@ src/templates/README.md
 
 **What this document provides:** The Kixx template syntax and behavior reference used by Hyperview — compilation stages, supported Mustache-style features, expression resolution, section semantics, built-in helpers, Hyperview helpers, escaping rules, partial usage, helper authoring, public APIs, and error behavior.
 
-### Static File Server Guide
-
-src/kixx/static-file-server/README.md
-
-**When to use this document:** Apply this guide whenever you are serving, configuring, or reviewing static file delivery (favicons, images, fonts). This includes:
-
-- Wiring `StaticFileRequestHandler` into routes in `virtual-hosts.js`, including the root-served catch-all pattern.
-- Choosing handler options for `Content-Type`, `Cache-Control`, ETag computation, not-found behavior, handler skipping, or pathname rewriting.
-- Working on the `StaticFileStore` contract or its Node.js (filesystem + `manifest.json`) and Cloudflare (dedicated KV binding) adapters.
-- Understanding Build ID namespacing for Atomic Deployments and how ETags are computed.
-
-**What this document provides:** The static file serving reference — `StaticFileRequestHandler` usage and options, the `StaticFileStore` keyed/namespaced lookup contract, the parts-object return shape, per-runtime adapter behavior, ETag and conditional-request handling, and the Atomic Deployment / Build ID model. For request-handler wiring in the application presentation layer, see the Presentation Layer Guide above.
-
 ### Frontend Development Guide
 
 src/docs/frontend-development-guide.md
@@ -145,7 +132,7 @@ Change the --port option to avoid port conflicts if needed.
 
 The wrapper restarts the child app server after the site has been idle for a few seconds, so JavaScript source changes are picked up on the next request without manually restarting the command. Server restarts are not needed for changes to `templates/`, `pages/` data, or source stylesheets under `src/stylesheets/`.
 
-The dev server also serves CSS files directly from `src/stylesheets/`, allowing you to skip a build process for CSS bundles.
+The dev server also serves CSS and JavaScript directly from `src/stylesheets/` and `src/javascript/`, allowing you to skip an asset build process. It recognizes `/assets/<build-id>/stylesheets/**` and `/assets/<build-id>/javascript/**` as source-file URLs in development, ignores the Build ID segment, and sends `Cache-Control: no-cache` so edits appear on reload. The bare `/stylesheets/**` and `/javascript/**` source-file URLs remain available too.
 
 Add `.json` to the end of any URL to get the template context object as JSON (ecluding includes content):
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ node tools/devserver.js --port 2026
 
 The dev server listens on the public `--port` and proxies requests to a child `src/node-server.js` process on a temporary port. It restarts the child after the app has been idle for a few seconds, so JavaScript source changes are picked up on the next request without manually restarting the command. Template, page data, and source stylesheet changes are read directly on reload.
 
-The dev server also serves CSS files directly from `src/stylesheets/`, allowing you to skip a build process for CSS bundles.
+The dev server also serves CSS and JavaScript directly from `src/stylesheets/` and `src/javascript/`, allowing you to skip an asset build process. It recognizes `/assets/<build-id>/stylesheets/**` and `/assets/<build-id>/javascript/**` as source-file URLs in development, ignores the Build ID segment, and sends `Cache-Control: no-cache` so edits appear on reload. The bare `/stylesheets/**` and `/javascript/**` source-file URLs remain available too.
 
 The wrapper accepts the same `--environment` and `--dotenv` options as `src/node-server.js`. Change `--port` to avoid local port conflicts.
 

--- a/agents/plans/stateless-csrf-tokens-implementation-plan.md
+++ b/agents/plans/stateless-csrf-tokens-implementation-plan.md
@@ -1,0 +1,564 @@
+# Stateless CSRF Tokens Implementation Plan
+
+Replace the KV-backed CSRF pre-session with an HMAC-signed stateless token, removing every
+Key/Value Store read and write from the CSRF subsystem without changing the handler-facing
+API, the wire format, or any template.
+
+## Implementation Approach
+
+Today every CSRF operation touches the Key/Value Store. One admin login costs **3 writes and
+2 reads**:
+
+| Step | KV operations |
+|---|---|
+| `GET` login page → `getCsrfFormContext()` | 1 write (`createToken` or `issueToken`) |
+| `POST` → `validateCsrfFormData()` → `validateToken()` | 1 read |
+| `POST` → `consumeToken()` | 1 read + 1 write (put or delete) |
+| `POST` → `clearCsrfToken()` | 1 write (delete) |
+
+Each failed submission that re-renders the form adds another write. Both write sources trace
+to a single decision: token hashes are **stored server-side** and tokens are **single-use**.
+Minting is a write; spending is a write.
+
+The replacement keeps the synchronizer token pattern but moves the state into the signature.
+A random pre-session id (`sid`) lives in the existing `kixx_csrf_session` cookie — client
+state, free to write. The form field carries an HMAC envelope over `{sid, exp}`. Verification
+recomputes the HMAC and compares `payload.sid` against the cookie, so it is a pure function of
+data the request already carries plus a deploy-time secret. **Zero KV operations on both GET
+and POST.**
+
+This also removes a latent correctness bug on Cloudflare. Workers KV is eventually consistent
+— a write is immediately visible in the colo that made it, but other colos can serve stale
+reads for up to ~60 seconds. The current flow writes on `GET` in one colo and reads on `POST`
+in whichever colo the submission lands in, which is precisely the pattern KV is worst at, and
+produces spurious "form has expired" rejections invisible in development because SQLite is
+strongly consistent and single-node. The same eventual consistency is the cause of the
+lost-append race that `CsrfTokenCollection#issueToken()`'s docblock already concedes.
+
+Work lands in three partitions: a shared base64url utility and the signer itself (Task 1),
+rewiring `lib/csrf.js` onto the signer (Task 2), and deleting the now-dead storage layer and
+updating configuration and documentation (Task 3). Each task owns the unit tests for the
+behavior it introduces — tests are not deferred to a trailing task.
+
+### Cross-cutting decisions
+
+These were settled with the user before planning and should not be re-litigated:
+
+1. **Single-use replay protection is dropped, deliberately.** The user confirmed no surface
+   depends on it. Within the token TTL a token becomes replayable. CSRF protection itself is
+   unaffected — the attacker still cannot read the token cross-origin, which is the entire
+   threat model. Rails and Django both accept this same tradeoff. Note that
+   `postNewAdminUserForm()` does not lean on single-use for idempotency: invite consumption is
+   enforced in the domain layer, and `InviteSpentInEmailRace`
+   (`src/app/presentation/request-handlers/admin-panel/admin-users.js:241`) already handles
+   the concurrent-resubmit case where it belongs.
+2. **The handler-facing API does not change.** `getCsrfFormContext()`,
+   `renderWithFreshCsrf()`, `validateCsrfFormData()`, and `INVALID_CSRF_TOKEN_CODE` keep their
+   exact signatures and semantics. `clearCsrfToken()` is the one exception — it loses its now
+   unused `context` parameter. No request handler logic changes, and no template changes.
+3. **The wire format is preserved.** Cookie name `kixx_csrf_session`, form field name
+   `csrf_token`, and the `form.csrf.fieldName` / `form.csrf.token` render context are
+   unchanged. This is what keeps `test/end-to-end/test-helpers/authenticate.js` and every
+   `page.html` working untouched.
+4. **Binding `sid` inside the signed payload is mandatory**, not decorative. It is what makes
+   this a synchronizer token rather than plain double-submit. Double-submit's classic weakness
+   is an attacker who can write cookies via subdomain shadowing — they set both halves and
+   match them. Here they would additionally have to forge an HMAC over the injected `sid`,
+   which requires the server secret.
+5. **A separate secret**, `CSRF_TOKEN_SIGNING_SECRET`, read with
+   `context.getEnvString(..., { required: true })` at boot so a missing secret fails startup on
+   every platform rather than at first request. Not shared with
+   `DOCUMENT_STORE_CURSOR_SIGNING_SECRET` — distinct purpose, independent rotation.
+6. **Rotation invalidates in-flight forms, and that is accepted for v1.** Same documented
+   tradeoff already stated for the cursor secret in `src/example.env`. Multi-secret
+   verify-against-any rotation was considered and deferred; the token format chosen here
+   admits it later without a format change.
+7. **No targeted revocation.** A specific outstanding token can no longer be invalidated
+   globally, because it is never stored. The remaining levers are clearing the cookie
+   (per-browser, instant, no propagation — this is what `clearCsrfToken()` becomes) and
+   rotating the secret (global). The user confirmed no surface needs the targeted form.
+8. **No inverse coverage of the replaced behavior.** Do not write test cases asserting the
+   *absence* of the removed single-use semantics — specifically, no test asserting that
+   replaying a token succeeds. Replayability is a consequence of the new design, not a
+   property the system promises. Codifying it would lock the door against ever reintroducing
+   replay protection, and the test would fail spuriously the day someone does. Cover what the
+   new design guarantees, not what it stopped preventing. This does **not** exempt the new
+   design's own rejection paths: a forged, expired, malformed, or `sid`-mismatched token must
+   be proven to fail, and those cases are required (see Task 1).
+
+### Token format
+
+```
+token       = base64url(payloadBytes) "." base64url(signatureBytes)
+payloadBytes = utf8(JSON.stringify({ sid, exp }))
+signatureBytes = HMAC-SHA-256(secret, payloadBytes)
+```
+
+`sid` is the `kixx_csrf_session` cookie value (a `generateSecretToken()` hex string). `exp` is
+whole Unix seconds. This mirrors `DocumentStore#sealCursor()`
+(`src/kixx/document-store/document-store.js:176-182`), which is the existing precedent in this
+codebase for a signed stateless value and should be followed rather than reinvented.
+
+Verification must run in this order and **fail closed and uniformly** at every step — one
+boolean `false`, one error message, no distinguishing detail that would build an oracle:
+
+1. Split on `.` — exactly two non-empty segments.
+2. base64url-decode both segments; the canonical-form check rejects permissive `atob()` decodes.
+3. `crypto.subtle.verify('HMAC', key, signature, payloadBytes)`.
+4. `JSON.parse` the payload through a fatal UTF-8 decoder.
+5. Shape check: `sid` a non-empty string, `exp` an integer.
+6. `exp > now`.
+7. `payload.sid === cookieSid`.
+
+Signature comparison is constant-time inside `crypto.subtle.verify`. The `sid` string compare
+at step 7 uses `===`; both operands are attacker-supplied in an attack scenario and no secret
+is involved, so a non-constant-time compare leaks nothing.
+
+### Distributed-system notes for the implementing agent
+
+- **No cross-node coordination exists in this design.** Any colo verifies any token minted by
+  any other colo. There is no affinity or sticky-session requirement.
+- **Clock skew is a non-issue.** `exp` is compared against each node's `Date.now()`. Cloudflare
+  machines are NTP-synced to within milliseconds against a 30-minute TTL. Workers additionally
+  freezes `Date.now()` between I/O operations as a Spectre mitigation, so the clock can lag a
+  request by a few milliseconds — expected behavior, not a bug, and irrelevant at this TTL. Do
+  not add a skew-tolerance window.
+- **Import the `CryptoKey` once per instance, never per request.** Store the *promise* returned
+  by `crypto.subtle.importKey()` and `await` it at each use, exactly as
+  `DocumentStore` does with `#cursorSigningKey`
+  (`src/kixx/document-store/document-store.js:146-161`). Workers isolates persist instance
+  state across requests, so this amortizes to zero.
+- **Concurrent first-GET from a cookie-less browser remains an edge case and is not a
+  regression.** Two tabs opened simultaneously with no cookie each mint a different `sid` and
+  set a cookie; the browser keeps whichever `Set-Cookie` arrived last, and the losing tab's
+  form is bound to a dead `sid`. The current design fails identically (two `createToken()`
+  calls, two records, one surviving cookie). The window is narrow and the failure is
+  recoverable through the existing `InvalidCsrfTokenError` re-render path. Do not attempt to
+  fix it in this work.
+
+### Cookie lifetime
+
+The cookie carries only a `sid`, which is not a credential on its own — an attacker holding it
+cannot forge a token for it without the secret. The token's signed `exp` is the real time
+bound. Set the cookie on every form render with `maxAge = CSRF_TOKEN_TTL_SECONDS`, refreshing
+it, so the cookie always outlives a token minted in the same response. All other attributes
+(`path: '/'`, `httpOnly`, `sameSite: 'Lax'`, `secure: isSecureRequest(request)`) are unchanged.
+The `maxAge`-tracks-remaining-pre-session-lifetime logic in the current
+`getCsrfFormContext()` disappears along with the record it was tracking.
+
+### Test strategy
+
+The user has explicitly asked for unit test coverage of this work, so writing **and running**
+the tests described below is in scope for the task that owns them. Follow
+`test/unit-tests/README.md` for the runner API, `MockTracker` usage, hook semantics, and the
+patterns for asserting thrown errors and rejected promises. Test files mirror the source tree.
+
+Four facts set the shape of the coverage:
+
+- **`test/unit-tests/app/presentation/lib/csrf.test.js` (248 lines) cannot be salvaged
+  incrementally.** Its `makeHarness()` mocks a `CsrfToken` collection and asserts on
+  `collection.consumed` and `collection.deleted` — state that stops existing at Task 2. The
+  file is rewritten, not patched, and Task 2 owns it. Do not try to preserve its harness.
+- **`test/unit-tests/kixx/document-store/document-store.test.js` already covers the moved
+  base64url helpers indirectly**, through cursor seal/unseal, tamper rejection ("Invalid
+  document store cursor"), and a replacement-signing-secret case. It is the regression proof
+  that Task 1's extraction changed no behavior, and Task 1 must run it. No new cases are
+  needed there.
+- **`src/app/app.js` is pure wiring and has no unit test today**, consistent with how this
+  suite treats `src/virtual-hosts.js`. Task 3 adds none; a test of `registerService()` would
+  be testing the context, which `test/unit-tests/kixx/` already covers. Task 3 is proven by
+  the full-suite run plus its manual boot checks.
+- **`test/end-to-end/` needs no changes.** The helpers scrape the token from rendered HTML and
+  reuse the cookie, both of which the preserved wire format keeps valid. E2E runs will require
+  `CSRF_TOKEN_SIGNING_SECRET` in the environment once Task 3 lands.
+
+New and rewritten files, each owned by the task that introduces the behavior:
+
+| File | Owner | Covers |
+|---|---|---|
+| `test/unit-tests/kixx/utils/base64url.test.js` | Task 1 | Round-trip and canonical-form rejection |
+| `test/unit-tests/app/presentation/lib/csrf-token-signer.test.js` | Task 1 | Envelope, fail-closed contract, cross-instance verification |
+| `test/unit-tests/app/presentation/lib/csrf.test.js` | Task 2 | Rewritten: cookie handling, `sid` reuse, render context, rejection propagation |
+
+`test/unit-tests/kixx/utils/crypto.test.js` and
+`test/unit-tests/app/presentation/lib/admin-session-cookie.test.js` are the closest existing
+models — reuse their structure rather than inventing a new one.
+
+Cross-cutting decision 8 governs all of it: cover the guarantees the new design makes, and do
+not write a case asserting that a replayed token is accepted.
+
+---
+
+### Task 1: HMAC-signed CSRF token envelope
+
+**Status:** Not started
+**Depends on:** None
+**Documentation:** Token format and distributed-system notes above; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `test/unit-tests/README.md`; `src/plugins/README.md` (service registration lifecycle)
+
+**Objective**
+
+A `CsrfTokenSigner` that mints and verifies stateless CSRF tokens using HMAC-SHA-256 over a
+`{sid, exp}` payload, holding its `CryptoKey` for the life of the instance and touching no
+storage. Standalone, independently exercisable, and under test before anything consumes it.
+
+**Scope**
+
+- In: the base64url encode/decode utility extracted for shared use; the signer module; its
+  key import and lifecycle; the sign and verify envelope; unit tests for both new modules;
+  the existing document-store regression run that proves the extraction was behavior-neutral.
+- Out: all `lib/csrf.js` rewiring and its test rewrite (Task 2); service registration in
+  `app.js` and env configuration (Task 3); deleting the collection and record (Task 3).
+
+**Design and invariants**
+
+- `bytesToBase64Url()` / `base64UrlToBytes()` are currently file-private in
+  `src/kixx/document-store/document-store.js:637-669`. Extract them verbatim into
+  `src/kixx/utils/base64url.js` and update `document-store.js` to import them. This is a pure
+  move with no behavior change. Duplicating them is not acceptable: the canonical-form
+  round-trip check in `base64UrlToBytes()` is security-relevant, and two copies will drift.
+  The `BASE64URL_PATTERN` constant moves with them.
+- Follow the small-focused-module convention already visible in `src/kixx/utils/`.
+- The signer stores the **promise** from `crypto.subtle.importKey()`, never the raw secret
+  string, and never re-imports per call.
+- `verify()` returns a boolean. It never throws for a malformed, forged, or expired token, and
+  never reports *which* check failed. Malformed input is an expected condition here, not a
+  programmer error — see `src/docs/server-error-handling.md`.
+- The signer knows nothing about cookies, requests, or responses. It takes a `sid` string and
+  returns/validates a token string. Cookie handling belongs to `lib/csrf.js` (Task 2).
+- `verify()` takes the expected `sid` as a parameter and performs the step-7 comparison
+  itself, so no caller can forget it.
+- The constructor asserts a non-empty secret, per `src/docs/server-error-handling.md` rules for
+  internal invariants.
+
+**Expected touch points**
+
+- `src/kixx/utils/base64url.js` — new; extracted encode/decode helpers plus `BASE64URL_PATTERN`.
+- `src/kixx/document-store/document-store.js` — remove the two private functions and the
+  pattern constant; import from the new module.
+- `src/app/presentation/lib/csrf-token-signer.js` — new; the signer class.
+- `test/unit-tests/kixx/utils/base64url.test.js` — new.
+- `test/unit-tests/app/presentation/lib/csrf-token-signer.test.js` — new.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `src/kixx/utils/base64url.js` exports both helpers; `document-store.js` imports them and
+      retains byte-identical cursor behavior.
+- [ ] `CsrfTokenSigner` exposes an async `sign(sid, ttlSeconds)` returning the two-segment
+      token, and an async `verify(token, sid)` returning a boolean.
+- [ ] The `CryptoKey` is imported at most once per instance.
+- [ ] `verify()` returns `false` — never throws, never distinguishes causes — for: a token with
+      the wrong segment count, non-canonical base64url, a bad signature, a non-UTF-8 or
+      non-JSON payload, a malformed `sid` or `exp`, an expired `exp`, and a `sid` mismatch.
+- [ ] A token minted by one signer instance verifies against a second instance constructed
+      with the same secret, and fails against one constructed with a different secret. This is
+      the cross-node property the whole design rests on.
+- [ ] JSDoc per `src/docs/code-documentation-guide.md` on the class and both public methods,
+      documenting the fail-closed contract.
+
+**Test coverage owned by this task**
+
+`test/unit-tests/kixx/utils/base64url.test.js`:
+
+- [ ] Round-trips arbitrary bytes, including empty input and bytes that encode with padding.
+- [ ] Produces URL-safe output: no `+`, `/`, or trailing `=`.
+- [ ] Rejects a non-canonical encoding that permissive `atob()` would otherwise accept — the
+      round-trip check is the security-relevant behavior and is the reason this module is
+      shared rather than duplicated.
+- [ ] Rejects input containing characters outside the base64url alphabet.
+
+`test/unit-tests/app/presentation/lib/csrf-token-signer.test.js`:
+
+- [ ] A signed token verifies against the `sid` it was minted for.
+- [ ] The token is two `.`-separated base64url segments, and the payload decodes to the
+      expected `{sid, exp}` — asserted by decoding, so the format stays pinned for the future
+      multi-secret rotation described in cross-cutting decision 6.
+- [ ] `exp` is `ttlSeconds` in the future, in whole Unix seconds.
+- [ ] One rejection case per reason listed in the acceptance criteria above, each asserting a
+      returned `false` rather than a throw. Drive the expiry case by signing with a short or
+      zero TTL rather than by mocking the clock.
+- [ ] Cross-instance: same secret verifies, different secret rejects. Model this on the
+      replacement-signing-secret case already in `document-store.test.js`.
+- [ ] `crypto.subtle.importKey` is called at most once across many `sign()`/`verify()` calls,
+      via `MockTracker`. This is the Workers-isolate amortization property and is invisible to
+      every behavioral assertion, so it needs its own case.
+
+Per cross-cutting decision 8, do not add a case asserting a token verifies twice.
+
+**Validation**
+
+- `node run-linter.js src/kixx/utils/base64url.js src/kixx/document-store/document-store.js src/app/presentation/lib/csrf-token-signer.js`
+- `node run-tests.js test/unit-tests/kixx/utils test/unit-tests/app/presentation/lib` — proves
+  the new modules.
+- `node run-tests.js test/unit-tests/kixx/document-store` — proves the base64url extraction was
+  behavior-neutral. This existing file already exercises cursor seal/unseal, tamper rejection,
+  and secret replacement, so it is the regression gate for the move; it must pass unmodified.
+- Manual: the document store's cursor pagination is the only runtime consumer of the moved
+  helpers. Start the dev server, open the admin invite list (`/admin/invites`), and page
+  forward and back.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: None yet.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.
+
+---
+
+### Task 2: Rewire the CSRF helpers onto the signer
+
+**Status:** Not started
+**Depends on:** Task 1
+**Documentation:** Cookie lifetime and cross-cutting decisions above; `src/app/presentation/README.md` §"CSRF-Protected HTML Forms" (lines ~859-905); `src/docs/server-error-handling.md`; `test/unit-tests/README.md`
+
+**Objective**
+
+`src/app/presentation/lib/csrf.js` mints and validates tokens through `CsrfTokenSigner`,
+performing zero Key/Value Store operations, while every request handler and template that
+consumes it continues to work without modification.
+
+**Scope**
+
+- In: `issueCsrfToken()` replaced by signer-backed minting; `getCsrfFormContext()` cookie
+  handling; `validateCsrfFormData()` verification; `clearCsrfToken()` reduced to a cookie
+  expiry; the two `clearCsrfToken()` call sites; the CSRF section of the presentation README;
+  the full rewrite of `test/unit-tests/app/presentation/lib/csrf.test.js`.
+- Out: registering the signer service and reading the env secret (Task 3); deleting the
+  collection and record (Task 3); any change to handler control flow, form classes, or
+  templates.
+
+**Design and invariants**
+
+- `getCsrfFormContext()`, `renderWithFreshCsrf()`, and `validateCsrfFormData()` keep their
+  exact exported signatures. `getCsrfFormContext()` remains async — `crypto.subtle.sign()` is
+  async — so no call site changes.
+- `clearCsrfToken(request, response)` loses the unused `context` parameter. Update both call
+  sites: `admin-users.js:289` (signup success) and `admin-users.js:404` (login success). Do not
+  leave an unused parameter behind; `eslint.config.js` will flag it and it misrepresents the
+  function's dependencies.
+- The signer is reached via `context.getService('CsrfTokenSigner')`, mirroring how
+  `lib/csrf.js` reaches `context.getCollection('CsrfToken')` today. Task 3 registers it; until
+  then this task's code will throw at runtime on a service lookup, which is expected and is why
+  the two tasks share a manual validation pass.
+- Minting logic replacing `issueCsrfToken()`: read `kixx_csrf_session`; reuse the `sid` when
+  the cookie holds a non-empty string, otherwise `generateSecretToken()`. Reusing the existing
+  `sid` is what preserves the multi-tab property — a second tab must not invalidate a form
+  already on screen. Always `sign()` a fresh payload and always re-set the cookie with
+  `maxAge: CSRF_TOKEN_TTL_SECONDS`.
+- `MIN_REUSABLE_SECONDS`, `isReusable()`, and the remaining-lifetime `maxAge` calculation have
+  no analogue and must not be carried over. They existed only to decide whether a stored record
+  could still be written to.
+- `validateCsrfFormData()` keeps owning `request.formData()` (bodies are one-shot) and keeps
+  throwing `ForbiddenError` with `INVALID_CSRF_TOKEN_CODE` and the same user-facing message on
+  failure, so every handler recovery path in `admin-invites.js` and
+  `admin-publishing-api-tokens.js` keeps working untouched.
+- Delete the token-consumption step entirely. There is nothing to spend.
+- Rewrite the module's existing comments rather than leaving them in place. The current
+  docblocks explain pre-session reuse, single-use spending, and record lifetime — all of which
+  become actively misleading. Per `src/docs/code-style-guide.md`, stale comments are a defect.
+- Update the presentation README's CSRF section in this task, not Task 3: it currently
+  documents "mints a fresh single-use CSRF token", which is false the moment this task lands.
+
+**Expected touch points**
+
+- `src/app/presentation/lib/csrf.js` — the whole minting and validation path, and its comments.
+- `src/app/presentation/request-handlers/admin-panel/admin-users.js` — two `clearCsrfToken()`
+  call sites.
+- `src/app/presentation/README.md` — the CSRF-Protected HTML Forms section.
+- `test/unit-tests/app/presentation/lib/csrf.test.js` — rewritten.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `lib/csrf.js` contains no `getCollection('CsrfToken')` call and no storage access of any
+      kind.
+- [ ] `getCsrfFormContext()` returns the same `{csrf: {fieldName, token}}` shape merged onto
+      the form context, and sets `kixx_csrf_session` with unchanged attributes plus
+      `maxAge: CSRF_TOKEN_TTL_SECONDS`.
+- [ ] An existing cookie's `sid` is reused rather than replaced, so a second render does not
+      invalidate a form already rendered.
+- [ ] `validateCsrfFormData()` accepts a token minted for the cookie it was rendered with, and
+      rejects a missing cookie, a missing field, a forged token, an expired token, and a token
+      bound to a different `sid` — all with `INVALID_CSRF_TOKEN_CODE`.
+- [ ] `clearCsrfToken(request, response)` expires the cookie and performs no storage call.
+- [ ] No request handler's control flow changed; no template changed.
+- [ ] Comments and JSDoc describe the stateless model, with no surviving reference to
+      pre-sessions, reuse thresholds, or single-use spending.
+
+**Test coverage owned by this task**
+
+`test/unit-tests/app/presentation/lib/csrf.test.js` is rewritten from scratch. The old
+harness mocks a `CsrfToken` collection; the new one supplies a stub `context.getService()`
+returning a real `CsrfTokenSigner` built on a fixed test secret. Use a real signer rather than
+a mock — the interesting behavior in this module is the interaction between cookie and token,
+and a mocked signer would assert nothing about it. `admin-session-cookie.test.js` is the model
+for asserting cookie attributes on a stubbed response.
+
+- [ ] `getCsrfFormContext()` returns `csrf.fieldName` and `csrf.token`, merged onto the form
+      context without disturbing the properties `form.getFormContext()` supplied.
+- [ ] It sets `kixx_csrf_session` with `path: '/'`, `httpOnly`, `sameSite: 'Lax'`, and
+      `maxAge: CSRF_TOKEN_TTL_SECONDS`.
+- [ ] `secure` follows `isSecureRequest(request)` in both directions.
+- [ ] **`sid` reuse:** given a request already carrying a cookie, the response re-sets that
+      same `sid` rather than minting a new one, and the token it returns verifies against it.
+      This is the multi-tab invariant — the single most important case in the file.
+- [ ] **No cookie:** a fresh `sid` is minted and set, and its token verifies against it.
+- [ ] **Independent tokens:** two successive renders against the same cookie both produce
+      tokens that verify. (Assert that both are valid — not that either can be used twice.)
+- [ ] `validateCsrfFormData()` returns the parsed `FormData` when the token matches the cookie.
+- [ ] It throws `ForbiddenError` with `INVALID_CSRF_TOKEN_CODE` and status 403 for: no cookie,
+      no `csrf_token` field, a forged token, an expired token, and a token minted for a
+      different `sid`. Handler recovery paths match on that code, so the code — not just the
+      throw — is the contract under test.
+- [ ] It performs no storage access; the stub context exposes no collection, so a stray
+      `getCollection()` call fails the test loudly.
+- [ ] `renderWithFreshCsrf()` sets the response status from an explicit `status`, falls back to
+      `error.httpStatusCode`, and defaults to 500 — the three branches at `csrf.js:87`.
+- [ ] `clearCsrfToken(request, response)` sets the cookie to an empty value with `maxAge: 0`
+      and makes no storage call.
+
+Per cross-cutting decision 8, do not add a case submitting the same token twice and asserting
+both succeed.
+
+**Validation**
+
+- `node run-linter.js src/app/presentation/lib/csrf.js src/app/presentation/request-handlers/admin-panel/admin-users.js`
+- `node run-tests.js test/unit-tests/app/presentation/lib`
+- Manual (run after Task 3 wires the service; these are the acceptance path for both tasks):
+  1. `node tools/devserver.js --port 2026` with `CSRF_TOKEN_SIGNING_SECRET` set.
+  2. `GET /login/admin/new` — confirm a `csrf_token` hidden field and a `kixx_csrf_session`
+     cookie in the response.
+  3. Submit valid credentials — login succeeds and the CSRF cookie is cleared.
+  4. Submit with the hidden field's value altered by one character — expect the recoverable
+     rejection, not a generic 403 page.
+  5. Submit with the `kixx_csrf_session` cookie deleted from the request — expect rejection.
+  6. Open the invite form in two tabs, submit the **first** tab — it must succeed. This is the
+     multi-tab regression that the `sid`-reuse rule protects, and it is the single most
+     important manual check in this plan.
+  7. Submit the same captured token twice — both now succeed. This is a one-time manual
+     confirmation that the approved behavior change actually landed; note the result in the
+     handoff. Per cross-cutting decision 8, do **not** promote it into a test case.
+  8. Verify no KV writes occur during any of the above.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: None yet.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.
+
+---
+
+### Task 3: Register the signer, remove the storage layer
+
+**Status:** Not started
+**Depends on:** Task 2
+**Documentation:** `src/plugins/README.md` (two-phase `register()`/`initialize()` lifecycle); `src/app/collections/README.md`; cross-cutting decision 5 above
+
+**Objective**
+
+`CsrfTokenSigner` is registered as a service and initialized from a required environment
+secret at boot, and the CSRF pre-session collection, record, and their registration are gone
+from the codebase.
+
+**Scope**
+
+- In: service registration and initialization in `app/app.js`; the `CSRF_TOKEN_SIGNING_SECRET`
+  env var and its documentation; deletion of `csrf-token-collection.js` and
+  `csrf-token-record.js` and the `registerCollection('CsrfToken', ...)` line; the full-suite
+  test run that proves nothing else depended on the deleted modules.
+- Out: any behavior change to `lib/csrf.js` (Task 2); new unit tests — see the note below.
+
+**Design and invariants**
+
+- Read the secret in `initialize()` with `context.getEnvString(CSRF_TOKEN_SIGNING_SECRET,
+  { required: true })`, exactly matching the `DOCUMENT_STORE_CURSOR_SIGNING_SECRET` pattern at
+  `src/app/app.js:41`. Boot must fail loudly on a missing secret rather than deferring the
+  failure to the first form render — a silently unsigned CSRF subsystem is a security failure,
+  not a degraded mode.
+- Follow the two-phase lifecycle: `register()` constructs and registers, `initialize()` supplies
+  configuration. Follow whichever shape reads most naturally against the existing
+  `DocumentStore` wiring, and keep `register()` pure wiring.
+- Deleting the collection is safe only after Task 2 removes the last reference. Verify with a
+  repo-wide grep for `CsrfToken` before deleting, and confirm the only hits are the deletions
+  themselves.
+- Add `CSRF_TOKEN_SIGNING_SECRET` to `src/example.env` with a comment matching the existing
+  cursor-secret note, stating that rotation invalidates every form currently open — anyone
+  mid-edit gets a rejection on submit.
+- Note in the handoff that Cloudflare deploys must supply this as a Workers Secret binding, and
+  that a deploy which rotates it while colos are mid-propagation will reject tokens across the
+  version boundary for the length of one TTL.
+
+**Expected touch points**
+
+- `src/app/app.js` — import, service registration, `initialize()` secret read; remove the
+  `CsrfToken` collection import and registration.
+- `src/app/collections/csrf-token-collection.js` — delete.
+- `src/app/collections/csrf-token-record.js` — delete.
+- `src/example.env` — new documented secret.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `CsrfTokenSigner` is registered and reachable via `context.getService()` from a request
+      handler.
+- [ ] Starting the server without `CSRF_TOKEN_SIGNING_SECRET` fails at boot with a clear
+      message naming the variable.
+- [ ] Both collection files are deleted and a repo-wide grep for `CsrfToken` returns only
+      `CsrfTokenSigner` hits.
+- [ ] `src/example.env` documents the new secret and its rotation consequence.
+- [ ] No remaining code path writes to the Key/Value Store for CSRF purposes.
+- [ ] The full unit suite passes, including the collection tests that remain after the two
+      CSRF files are deleted.
+
+**Test coverage owned by this task**
+
+**None, deliberately.** `src/app/app.js` is pure wiring, and this suite has no test for it —
+the same treatment `src/virtual-hosts.js` gets. A test asserting that `registerService()`
+registers a service would be testing `ApplicationContext`, which
+`test/unit-tests/kixx/` already covers, and would pin the wiring shape in place without
+proving anything about this feature.
+
+Deleting `csrf-token-collection.js` and `csrf-token-record.js` removes no test files: neither
+has a dedicated test today (`test/unit-tests/app/collections/` covers the base collection and
+record plus the *other* record types). The full-suite run below is what proves nothing else
+imported them.
+
+The boot-failure behavior on a missing secret is verified manually rather than by unit test,
+because it is a property of process startup and `getEnvString()` already owns the `required`
+contract under `test/unit-tests/kixx/`.
+
+**Validation**
+
+- `node run-linter.js src/app/app.js`
+- `node run-tests.js` — the full suite. This is the gate that proves the deletions broke no
+  remaining import, and that Tasks 1 and 2 left the rest of the suite green.
+- Manual: start the dev server with the secret unset and confirm the boot failure names the
+  variable; set it and confirm normal startup. Then run the full Task 2 manual sequence, which
+  is the end-to-end acceptance path for the feature.
+- Manual: confirm the KV store shows no new CSRF entries across a full login and a full invite
+  creation. On Node this is inspectable directly in
+  `./data/nodejs_app/key_value_store.sqlite`.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: None yet.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.

--- a/agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md
+++ b/agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md
@@ -1,0 +1,454 @@
+# Static Asset Publishing Immutability and Build ID Validation Implementation Plan
+
+Close the two publishing-contract gaps introduced by Build-ID-addressed immutable asset
+URLs: make a static asset address write-once under ordinary sequential Publishing API use,
+and establish one shared definition of a real Build ID that cannot collide with the `dev`
+no-build URL placeholder.
+
+## Implementation Approach
+
+The public asset identity is the pair `(Build ID, filepath)`. The first successful
+`PUT /publishing-api/v1/assets/<filepath>` fixes the bytes and normalized content type at
+that identity. A later sequential PUT to the same identity follows one of two paths:
+
+- When the incoming bytes, byte length, and normalized content type match the stored asset,
+  it is an idempotent retry. The API returns the existing asset description with HTTP 200
+  and does not call `StaticFileStore.write()` again.
+- When any of those values differ, or the existing asset has no strong validator with which
+  the server can prove equality, the API returns `409 Conflict` and leaves the stored asset
+  untouched. Changed output must be published under a new Build ID.
+
+The transaction script will compute the incoming strong ETag, read the target address with
+`computeEtag: true`, cancel the returned body stream, and compare the stored parts before
+deciding whether to return, conflict, or write. The strong-ETag construction currently
+duplicated in the two static-file-store adapters will move to one framework helper used by
+the adapters and transaction script, keeping the comparison byte-identical across Node.js
+and Cloudflare.
+
+This is deliberately a **sequential** write guarantee. Per the user's decision, the work
+does not add a lock, reservation record, compare-and-set store operation, or build lifecycle.
+Two concurrent first PUTs to the same address can both observe a miss and the backing store
+may apply them last-writer-wins. Publishing clients must serialize writes to the same
+`(Build ID, filepath)`. Concurrent writes to different asset addresses remain supported.
+
+Build IDs get a shared contract in `src/kixx/utils/build-id.js`. A real Build ID is a
+non-empty, case-preserving, URL-safe **single path segment** using the existing conservative
+pathname character rules; it contains no slash, has no leading dot or `..`, and is not the
+reserved `NO_BUILD_ID_SEGMENT` value `dev`. The placeholder remains valid only at the asset
+read boundary, where it maps to the flat store root. All Publishing API workflows that
+accept `Kixx-Build-Id` validate real IDs before persistence, and `AppRuntime` rejects an
+invalid configured `BUILD_ID` at startup while continuing to allow a missing build ID.
+
+No deployed-data migration or compatibility mode is needed. The user confirmed that
+existing deployments do not use `dev` or other non-URL-safe Build IDs.
+
+The existing wire addresses remain unchanged:
+
+```text
+PUT /publishing-api/v1/assets/stylesheets/stylesheet.css
+Kixx-Build-Id: <build-id>
+
+GET /assets/<build-id>/stylesheets/stylesheet.css
+```
+
+The first write and an identical retry both remain HTTP 200 responses with the existing
+JSON:API resource shape. Only a conflicting retry adds new observable behavior: HTTP 409
+with error code `StaticAssetImmutableConflict`.
+
+---
+
+### Task 1: Enforce one real Build ID contract at runtime, publishing, and asset-read boundaries
+
+**Status:** Not started
+**Depends on:** None
+**Documentation:** `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `src/docs/server-error-handling.md`, `src/app/transaction-scripts/README.md`, `src/app/presentation/README.md`, `src/kixx/static-file-server/README.md`, `test/unit-tests/README.md`
+
+**Objective**
+
+Every real Build ID accepted by the application round-trips through the
+`/assets/:build_id/*pathname` URL as exactly one safe segment, while the reserved `dev`
+placeholder can represent only the flat no-build asset root. Invalid external Build IDs
+produce a client-visible 400 before persistence; invalid runtime configuration fails fast
+as an assertion during startup.
+
+**Scope**
+
+- In: shared Build ID predicate/validation behavior, runtime Build ID validation, asset URL
+  parameter validation, every Publishing API transaction script that accepts or derives a
+  Build ID, unit coverage, and Build ID contract documentation.
+- Out: changing the `dev` placeholder value, lower-casing Build IDs, adding a maximum Build
+  ID length, changing asset or publishing routes, migrating stored namespaces, and adding a
+  build registry or lifecycle API.
+
+**Design and invariants**
+
+- Extend `src/kixx/utils/build-id.js`; do not create competing Build ID validators in the
+  presentation, Hyperview, or static-file-server modules.
+- Keep `NO_BUILD_ID_SEGMENT = 'dev'` as the no-build URL placeholder.
+- Export a pure `isValidBuildId(value)` predicate for internal/runtime assertions. It returns
+  true only for a non-empty string which:
+  - passes the existing `isValidPathname()` safety rules;
+  - contains no `/`, including a slash obtained by decoding a route parameter;
+  - is not exactly `NO_BUILD_ID_SEGMENT`.
+- Export `validateBuildId(value)` as the operational validator for external Build IDs.
+  Preserve the supplied case and
+  return the validated value unchanged. Use:
+  - `BadRequestError` with code `ReservedBuildId` when the value is exactly `dev`;
+  - `BadRequestError` with code `InvalidBuildId` for every other non-empty invalid value.
+  Required endpoints retain their existing `BuildIdRequired` error for a missing or empty
+  header; requiredness remains the owning transaction script's concern.
+- `AppRuntime` continues to accept an omitted `build`, `{ id: undefined }`, or `{ id: null }`
+  as a no-build runtime. When `build.id` is present, assert `isValidBuildId(build.id)` before
+  freezing the descriptor. Empty, malformed, multi-segment, and reserved IDs are programmer/
+  configuration errors and must throw `AssertionError`, not an operational HTTP error.
+- `StaticAssetRequestHandler` accepts `NO_BUILD_ID_SEGMENT` as its one special URL segment
+  and maps it to `namespace: null`. Every other segment must satisfy the real Build ID
+  validator before reaching `StaticFileStore.read()`. In particular, a decoded `a/b` value
+  must be rejected even though `validatePathname()` permits safe multi-segment pathnames.
+- Apply the real Build ID validator in all four Publishing API Transaction Scripts:
+  - `putStaticAsset()` and `putTemplate()` retain their required-header behavior, then
+    validate the supplied ID before comparing it with the current build or accessing a
+    service.
+  - `putPageMetadata()` and `putInclude()` keep their optional-header/current-build fallback,
+    then validate the effective Build ID before accessing Hyperview. This covers direct
+    non-HTTP callers as well as request handlers.
+- Preserve existing validation precedence unless the Build ID is the value under test. For
+  example, an empty static-asset body still reports `StaticAssetSourceRequired` before Build
+  ID validation, and a missing effective page/include build still reports
+  `CurrentBuildIdRequired`.
+- Do not treat `DEV` or other case variants as the placeholder. Build IDs and store
+  namespaces are case-sensitive and case-preserving; only the exact lowercase `dev` value
+  is reserved.
+
+**Test coverage**
+
+- Add `test/unit-tests/kixx/utils/build-id.test.js` covering safe IDs (including mixed case,
+  hyphen, underscore, and a non-leading dot), empty/non-string values, slash-containing
+  values, whitespace and other disallowed characters, leading-dot values, `..`, and the
+  exact reserved placeholder. Assert both predicate results and operational error codes.
+- Extend `test/unit-tests/kixx/context/app-runtime.test.js` to prove absent/null Build IDs
+  remain allowed, a valid ID remains exposed and frozen, and malformed or reserved IDs throw
+  `AssertionError` before the runtime is constructed.
+- Extend the `StaticAssetRequestHandler` unit group to prove `dev` still maps to `null`, a
+  valid real Build ID is preserved, and a decoded multi-segment value such as `build/child`
+  is rejected before store access.
+- Extend each publishing Transaction Script test file to prove malformed and reserved
+  explicit Build IDs are rejected before service access. For page metadata and includes,
+  retain coverage for the no-header fallback to a valid current Build ID.
+- Do not duplicate the full Build ID input matrix in every consumer test. The utility test
+  owns the matrix; consumer tests prove each boundary actually calls the shared contract.
+
+**Expected touch points**
+
+- `src/kixx/utils/build-id.js` — shared real-ID predicate, external validator, and reserved
+  placeholder contract.
+- `src/kixx/context/app-runtime.js` — fail-fast validation for configured real Build IDs.
+- `src/kixx/static-file-server/static-file-server-request-handlers.js` — distinguish the
+  allowed no-build placeholder from validated real Build ID URL segments.
+- `src/app/transaction-scripts/publishing/put-static-asset.js` — validate the required asset
+  target Build ID.
+- `src/app/transaction-scripts/publishing/put-template.js` — validate the required template
+  target Build ID.
+- `src/app/transaction-scripts/publishing/put-page-metadata.js` — validate the effective page
+  target Build ID.
+- `src/app/transaction-scripts/publishing/put-include.js` — validate the effective include
+  target Build ID.
+- `test/unit-tests/kixx/utils/build-id.test.js` — exhaustive Build ID contract coverage.
+- `test/unit-tests/kixx/context/app-runtime.test.js` — runtime configuration coverage.
+- `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js` —
+  asset route-segment boundary coverage.
+- `test/unit-tests/app/transaction-scripts/publishing/*.test.js` — Publishing API domain
+  boundary coverage.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] A real Build ID is accepted only when it is one safe, case-preserving URL segment and
+  is not `dev`.
+- [ ] Missing runtime Build IDs remain supported; configured invalid or reserved Build IDs
+  fail fast with `AssertionError`.
+- [ ] `/assets/dev/<key>` still reads the flat asset root, while no publishing workflow can
+  persist content under a real `dev` build namespace.
+- [ ] Every Publishing API workflow rejects an explicit reserved Build ID with HTTP 400 code
+  `ReservedBuildId` and another malformed ID with HTTP 400 code `InvalidBuildId`.
+- [ ] Existing missing-Build-ID and current-Build-ID behavior and error codes are unchanged.
+- [ ] All cases listed under **Test coverage** exist and pass.
+
+**Validation**
+
+- `node run-linter.js src/kixx/utils/build-id.js src/kixx/context/app-runtime.js src/kixx/static-file-server/static-file-server-request-handlers.js src/app/transaction-scripts/publishing test/unit-tests/kixx/utils test/unit-tests/kixx/context/app-runtime.test.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing` — no lint errors in the Build ID implementation or its tests.
+- `node run-tests.js test/unit-tests/kixx/utils/build-id.test.js test/unit-tests/kixx/context/app-runtime.test.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing` — focused Build ID behavior passes.
+- `node run-tests.js` — the full unit suite passes.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: The exact lowercase `dev` value is reserved; Build IDs remain
+  case-preserving. No compatibility migration is required.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.
+
+---
+
+### Task 2: Make sequential static-asset PUTs write-once and idempotent
+
+**Status:** Not started
+**Depends on:** Task 1
+**Documentation:** `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `src/docs/server-error-handling.md`, `src/app/transaction-scripts/README.md`, `src/kixx/static-file-server/README.md`, `src/plugins/README.md`, `test/unit-tests/README.md`
+
+**Objective**
+
+After the first successful sequential PUT to a `(Build ID, filepath)`, the Publishing API
+never changes that address. A byte-and-content-type-identical retry succeeds without a
+write; a conflicting retry returns 409 and preserves the first asset. Both runtime adapters
+and the transaction script use one strong-ETag function when identifying bytes.
+
+**Scope**
+
+- In: shared strong static-file ETag construction, both adapter call sites, sequential
+  read-before-write enforcement in `putStaticAsset()`, body-stream cleanup, error
+  translation, and focused unit coverage.
+- Out: atomic compare-and-set behavior, locks or reservation records, build staging/sealing,
+  changing `StaticFileStore.write()` into a create-only primitive, blocking out-of-band
+  deployment tooling, and changing the successful JSON:API response shape.
+
+**Design and invariants**
+
+- Add one framework-owned helper under `src/kixx/static-file-server/` which computes the
+  quoted strong ETag used by static files: SHA-256 lowercase hex wrapped in double quotes.
+  It delegates hashing to `sha256Hex()` and works with the same byte inputs accepted today.
+- Replace the inline quoted-SHA construction in both Node and Cloudflare static-file-store
+  adapters with the shared helper. This is a mechanical ownership change; their stored ETag
+  values and read/write behavior must remain byte-for-byte compatible.
+- Keep `StaticFileStore.write()` as an overwrite-capable low-level port. The Publishing API
+  Transaction Script owns the write-once business rule; out-of-band deploy tooling and
+  other future callers are not silently given new semantics.
+- In `putStaticAsset()`, retain the existing body, required Build ID, Build ID validity, and
+  current-build checks before store access. A request targeting the current build still
+  returns `CurrentBuildWriteConflict`, even if its bytes happen to match.
+- Compute the incoming strong ETag once, then call:
+
+  ```js
+  store.read(context, {
+      key: filepath,
+      namespace: buildId,
+      computeEtag: true,
+  })
+  ```
+
+- When the read returns `null`, call `store.write()` exactly as today. The store remains the
+  source of truth for the returned write parts; do not synthesize a successful first-write
+  response from the precomputed ETag.
+- When the read returns an asset, cancel its body before returning or throwing so a Node file
+  stream or binding stream is never leaked. Treat a null body as already cleaned up.
+- An existing asset is an identical retry only when all three comparisons match:
+  - stored `etag` equals the incoming strong ETag;
+  - stored `contentLength` equals the incoming byte length;
+  - stored `contentType` equals the request handler's normalized media type.
+- For an identical retry, do not call `write()`. Return the requested `filepath` together
+  with the existing `contentType`, `contentLength`, and `etag` in the same shape used by a
+  first write, so the request handler continues returning HTTP 200 with an unchanged
+  JSON:API schema. `StaticFileResult` does not carry a key, so do not expect one from
+  `read()`.
+- If any comparison differs, or the existing result has no strong ETag, throw
+  `ConflictError` with code `StaticAssetImmutableConflict` and a client-safe message stating
+  that the address already exists with different content or content type. Do not disclose
+  storage paths or validators in the error.
+- Translate unexpected `read()`, body-cancellation, and `write()` failures into
+  `AssertionError` with the original `cause` and a phase-specific message. Do not catch and
+  wrap the intentional `ConflictError`.
+- Document the agreed concurrency boundary in code and the public guide: publishing clients
+  must serialize PUTs to the same `(Build ID, filepath)`. The transaction script provides
+  no guarantee when two first writes race after both observe a miss. Do not imply that
+  Cloudflare KV provides compare-and-set semantics.
+
+**Test coverage**
+
+- Add a focused unit test for the shared ETag helper proving it returns the exact quoted
+  lowercase SHA-256 value expected by the existing adapters.
+- Update the `putStaticAsset` Transaction Script harness with tracked `read()` results and a
+  cancellable body double.
+- Prove a missing target is read with the exact key, namespace, and `computeEtag: true`, then
+  written once with the original bytes and normalized content type.
+- Prove an identical existing asset is cancelled, returned with its existing parts, and
+  never written.
+- Prove changed bytes with the same content type returns
+  `409 StaticAssetImmutableConflict`, cancels the existing body, and never writes.
+- Prove identical bytes with a changed content type returns the same conflict.
+- Prove a length mismatch or absent stored ETag is conservatively treated as a conflict.
+- Prove current-build rejection happens before both `read()` and `write()`.
+- Prove read, body-cancellation, and write failures become phase-appropriate
+  `AssertionError`s preserving `cause`.
+- Update the publishing request-handler test store double to implement `read()` as a miss by
+  default, and add one integration-style handler case showing an immutable `ConflictError`
+  propagates for the route's JSON:API error handler without a second write. Keep detailed
+  JSON:API serialization assertions in Task 3's end-to-end coverage.
+
+**Expected touch points**
+
+- `src/kixx/static-file-server/static-file-etag.js` — shared quoted strong-ETag computation.
+- `src/plugins/node-static-file-server/lib/static-file-server-store.js` — use the shared
+  helper without changing stored values.
+- `src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js` — use the same
+  helper without changing stored values.
+- `src/app/transaction-scripts/publishing/put-static-asset.js` — sequential read-before-write,
+  equality decision, stream cleanup, and immutable conflict.
+- `test/unit-tests/kixx/static-file-server/static-file-etag.test.js` — shared ETag behavior.
+- `test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js` — write-once
+  domain behavior and error translation.
+- `test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js`
+  — handler/store-double compatibility and conflict propagation.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] The Node adapter, Cloudflare adapter, and Publishing API comparison use one strong
+  static-file ETag helper and retain the existing quoted SHA-256 format.
+- [ ] The first sequential PUT to an unused address writes once and returns the existing
+  HTTP 200 resource contract.
+- [ ] An identical sequential retry returns HTTP 200 with the existing parts and performs
+  no write.
+- [ ] A sequential retry with different bytes, length, or normalized content type returns
+  `409 StaticAssetImmutableConflict`, performs no write, and leaves the first asset intact.
+- [ ] An existing asset without a strong ETag is never overwritten through the Publishing
+  API.
+- [ ] Every existing result body is cancelled on both idempotent and conflict paths.
+- [ ] Current-build protection and all pre-existing input errors remain unchanged.
+- [ ] The implementation and documentation explicitly state that concurrent first writes
+  to the same address are unsupported and not made atomic by this task.
+- [ ] All cases listed under **Test coverage** exist and pass.
+
+**Validation**
+
+- `node run-linter.js src/kixx/static-file-server src/plugins/node-static-file-server/lib/static-file-server-store.js src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js src/app/transaction-scripts/publishing/put-static-asset.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js` — no lint errors.
+- `node run-tests.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js` — focused immutable-write behavior passes.
+- `node run-tests.js` — the full unit suite passes.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: Sequential equality is defined by ETag, byte length, and
+  normalized content type. No concurrent-write guarantee is in scope.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.
+
+---
+
+### Task 3: Publish the corrected API contract in end-to-end coverage and documentation
+
+**Status:** Not started
+**Depends on:** Task 1, Task 2
+**Documentation:** `src/app/presentation/README.md`, `src/kixx/static-file-server/README.md`, `src/plugins/README.md`, `test/end-to-end/README.md`
+
+**Objective**
+
+The repository's executable Publishing API examples and written static-file contract agree
+with the new behavior: build-addressed assets are publicly reachable and immutable after
+their first sequential write; identical retries are safe; conflicting retries are 409; and
+`dev` is not a publishable Build ID.
+
+**Scope**
+
+- In: Publishing API end-to-end success/error cases, stale comments that describe the old
+  current-build-only reader, static-file-store interface documentation, and the static file
+  server guide.
+- Out: adding a standalone Publishing API specification site, testing concurrent races,
+  adding deletion/pruning behavior, changing authentication/authorization, and changing
+  deploy tooling outside this repository.
+
+**Design and invariants**
+
+- Replace the end-to-end scenario which currently expects two different payloads at the
+  same address to succeed. Keep its single-segment filepath coverage, but split the contract
+  into two observable cases, each using its own filepath so test order cannot make one case
+  depend on the other:
+  - two identical PUTs return 200 and the same resource parts;
+  - a second PUT with changed bytes returns a JSON:API 409 error with code
+    `StaticAssetImmutableConflict`.
+- After a conflicting retry, GET the public
+  `/assets/<build-id>/<filepath>` URL and prove it still returns the first bytes, content
+  type, and ETag with the immutable cache policy. This is now possible because the new asset
+  handler intentionally reads any stored Build ID, including the test run's staged ID.
+- Update the old end-to-end comments which say staged writes cannot be read back. The route
+  is public and namespace-addressed; immutability, not invisibility until promotion, is now
+  what makes that safe.
+- Add end-to-end error coverage showing `Kixx-Build-Id: dev` returns HTTP 400 with code
+  `ReservedBuildId`, and a representative malformed single-segment violation returns HTTP
+  400 with code `InvalidBuildId`. Unit tests own the exhaustive matrix and coverage of the
+  other Publishing API workflows.
+- Update the static-file-server guide to state:
+  - `/assets/<build-id>/<key>` can serve staged, current, or historical stored namespaces;
+  - the first sequential asset PUT fixes that address;
+  - identical retries return the existing resource without rewriting;
+  - conflicting bytes or content type return 409 and require a new Build ID;
+  - clients must serialize writes to the same address because no atomic concurrency
+    guarantee is provided;
+  - real Build IDs are safe URL segments and cannot equal `dev`.
+- Correct `static-file-server-store-interface.js` without changing its executable contract:
+  distinguish the current-build `StaticFileRequestHandler` lookup from the URL-namespaced
+  `StaticAssetRequestHandler` lookup, state that raw `write()` remains overwrite-capable,
+  and state that the Publishing API caller enforces sequential write-once behavior by
+  reading first.
+- Update `route-params.js` comments which still name `StaticFileRequestHandler` as the asset
+  reader; the case-preserving claim now belongs to `StaticAssetRequestHandler`.
+- Do not edit the completed historical plan
+  `agents/plans/static-asset-request-handler-implementation-plan.md`. This plan records the
+  follow-up correction rather than rewriting the earlier handoff.
+
+**Expected touch points**
+
+- `test/end-to-end/020-publishing-api/put-static-asset.test.js` — identical retry,
+  conflicting retry, and read-after-conflict behavior.
+- `test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` — reserved and malformed
+  Build ID JSON:API errors.
+- `src/kixx/static-file-server/README.md` — corrected public read/write and Build ID contract.
+- `src/kixx/static-file-server/static-file-server-store-interface.js` — accurate low-level
+  store and caller-responsibility documentation.
+- `src/app/presentation/request-handlers/publishing-api/route-params.js` — current asset
+  reader name in the case-preservation rationale.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] End-to-end coverage proves identical retries succeed without changing the resource.
+- [ ] End-to-end coverage proves conflicting retries return the expected JSON:API 409 and
+  the public asset URL still serves the first representation.
+- [ ] End-to-end coverage proves reserved and malformed Build IDs return their documented
+  HTTP 400 codes.
+- [ ] No current documentation claims that a stored staged namespace is unreachable until
+  promotion or that “not current” alone makes asset writes immutable.
+- [ ] Documentation clearly separates the overwrite-capable store port from the sequential
+  write-once Publishing API policy and records the lack of a concurrent-write guarantee.
+- [ ] The publishing route, asset route, successful JSON:API schema, and asset upload key
+  remain unchanged.
+
+**Validation**
+
+- `node run-linter.js src/kixx/static-file-server/static-file-server-store-interface.js src/app/presentation/request-handlers/publishing-api/route-params.js test/end-to-end/020-publishing-api/put-static-asset.test.js test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` — no lint errors in documentation-bearing JavaScript and end-to-end coverage.
+- `node run-tests.js` — the full unit suite still passes after documentation and end-to-end fixture changes.
+- `node run-tests.js --e2e --development test/end-to-end/020-publishing-api/put-static-asset.test.js test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` — focused local end-to-end behavior passes when the user explicitly authorizes starting the development server and running end-to-end tests.
+- `node run-tests.js --e2e --nodejs test/end-to-end/020-publishing-api/put-static-asset.test.js test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` — focused deployed-Node behavior passes when credentials, target configuration, and explicit authorization are available.
+- `node run-tests.js --e2e --cloudflare test/end-to-end/020-publishing-api/put-static-asset.test.js test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` — focused Cloudflare behavior passes when credentials, target configuration, and explicit authorization are available.
+
+**Progress and handoff**
+
+- Completed: Nothing yet.
+- Current state: Not started.
+- Remaining: Everything described above.
+- Decisions and discoveries: The API route and success schema remain stable. End-to-end tests
+  may now read staged test assets through the public Build-ID route.
+- Actual files changed: None yet.
+- Validation run: None yet.
+- Blockers: None.

--- a/agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md
+++ b/agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md
@@ -59,7 +59,7 @@ with error code `StaticAssetImmutableConflict`.
 
 ### Task 1: Enforce one real Build ID contract at runtime, publishing, and asset-read boundaries
 
-**Status:** Not started
+**Status:** Complete
 **Depends on:** None
 **Documentation:** `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `src/docs/server-error-handling.md`, `src/app/transaction-scripts/README.md`, `src/app/presentation/README.md`, `src/kixx/static-file-server/README.md`, `test/unit-tests/README.md`
 
@@ -185,19 +185,19 @@ actual files changed in the handoff notes.
 **Progress and handoff**
 
 - Completed: Nothing yet.
-- Current state: Not started.
-- Remaining: Everything described above.
+- Current state: Complete.
+- Remaining: Nothing.
 - Decisions and discoveries: The exact lowercase `dev` value is reserved; Build IDs remain
   case-preserving. No compatibility migration is required.
-- Actual files changed: None yet.
-- Validation run: None yet.
+- Actual files changed: `agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md`, `src/kixx/utils/build-id.js`, `src/kixx/context/app-runtime.js`, `src/kixx/static-file-server/static-file-server-request-handlers.js`, `src/app/transaction-scripts/publishing/put-static-asset.js`, `src/app/transaction-scripts/publishing/put-template.js`, `src/app/transaction-scripts/publishing/put-page-metadata.js`, `src/app/transaction-scripts/publishing/put-include.js`, `test/unit-tests/kixx/utils/build-id.test.js`, `test/unit-tests/kixx/context/app-runtime.test.js`, `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`, `test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js`, `test/unit-tests/app/transaction-scripts/publishing/put-template.test.js`, `test/unit-tests/app/transaction-scripts/publishing/put-page-metadata.test.js`, `test/unit-tests/app/transaction-scripts/publishing/put-include.test.js`.
+- Validation run: `node run-linter.js src/kixx/utils/build-id.js src/kixx/context/app-runtime.js src/kixx/static-file-server/static-file-server-request-handlers.js src/app/transaction-scripts/publishing test/unit-tests/kixx/utils test/unit-tests/kixx/context/app-runtime.test.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing` (passed); `node run-tests.js test/unit-tests/kixx/utils/build-id.test.js test/unit-tests/kixx/context/app-runtime.test.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing` (69 passed); `node run-tests.js` (1376 passed).
 - Blockers: None.
 
 ---
 
 ### Task 2: Make sequential static-asset PUTs write-once and idempotent
 
-**Status:** Not started
+**Status:** Complete
 **Depends on:** Task 1
 **Documentation:** `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `src/docs/server-error-handling.md`, `src/app/transaction-scripts/README.md`, `src/kixx/static-file-server/README.md`, `src/plugins/README.md`, `test/unit-tests/README.md`
 
@@ -334,19 +334,19 @@ actual files changed in the handoff notes.
 **Progress and handoff**
 
 - Completed: Nothing yet.
-- Current state: Not started.
-- Remaining: Everything described above.
+- Current state: Complete.
+- Remaining: Nothing.
 - Decisions and discoveries: Sequential equality is defined by ETag, byte length, and
   normalized content type. No concurrent-write guarantee is in scope.
-- Actual files changed: None yet.
-- Validation run: None yet.
+- Actual files changed: `agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md`, `src/kixx/static-file-server/static-file-etag.js`, `src/plugins/node-static-file-server/lib/static-file-server-store.js`, `src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js`, `src/app/transaction-scripts/publishing/put-static-asset.js`, `test/unit-tests/kixx/static-file-server/static-file-etag.test.js`, `test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js`, `test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js`.
+- Validation run: `node run-linter.js src/kixx/static-file-server src/plugins/node-static-file-server/lib/static-file-server-store.js src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js src/app/transaction-scripts/publishing/put-static-asset.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js` (passed); `node run-tests.js test/unit-tests/kixx/static-file-server test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js` (58 passed); `node run-tests.js` (1381 passed).
 - Blockers: None.
 
 ---
 
 ### Task 3: Publish the corrected API contract in end-to-end coverage and documentation
 
-**Status:** Not started
+**Status:** Complete
 **Depends on:** Task 1, Task 2
 **Documentation:** `src/app/presentation/README.md`, `src/kixx/static-file-server/README.md`, `src/plugins/README.md`, `test/end-to-end/README.md`
 
@@ -445,10 +445,10 @@ actual files changed in the handoff notes.
 **Progress and handoff**
 
 - Completed: Nothing yet.
-- Current state: Not started.
-- Remaining: Everything described above.
+- Current state: Complete, with end-to-end execution explicitly deferred pending user authorization to start a development server or target a configured deployment.
+- Remaining: No implementation work. Run the listed focused end-to-end commands only when expressly authorized and configured.
 - Decisions and discoveries: The API route and success schema remain stable. End-to-end tests
   may now read staged test assets through the public Build-ID route.
-- Actual files changed: None yet.
-- Validation run: None yet.
-- Blockers: None.
+- Actual files changed: `agents/plans/static-asset-publishing-immutability-and-build-id-validation-plan.md`, `test/end-to-end/020-publishing-api/put-static-asset.test.js`, `test/end-to-end/020-publishing-api/put-static-asset-errors.test.js`, `src/kixx/static-file-server/README.md`, `src/kixx/static-file-server/static-file-server-store-interface.js`, `src/app/presentation/request-handlers/publishing-api/route-params.js`.
+- Validation run: `node run-linter.js src/kixx/static-file-server/static-file-server-store-interface.js src/app/presentation/request-handlers/publishing-api/route-params.js test/end-to-end/020-publishing-api/put-static-asset.test.js test/end-to-end/020-publishing-api/put-static-asset-errors.test.js` (passed); `node run-tests.js` (1381 passed). Focused end-to-end commands were not run: the plan and repository instructions require explicit user authorization to start the development server or exercise configured targets.
+- Blockers: End-to-end execution awaits explicit user authorization and, for deployed targets, credentials and target configuration.

--- a/agents/plans/static-asset-request-handler-implementation-plan.md
+++ b/agents/plans/static-asset-request-handler-implementation-plan.md
@@ -1,0 +1,579 @@
+# Static Asset Request Handler Implementation Plan
+
+Split static file serving into two request handlers with different lookup rules and
+cache policies, and move the application's CSS and JavaScript onto Build-ID-namespaced,
+long-lived-cacheable URLs.
+
+## Implementation Approach
+
+Today `StaticFileRequestHandler` (`src/kixx/static-file-server/static-file-server-request-handlers.js`)
+serves every static file with one rule: the store key comes from the URL pathname and
+the namespace always comes from `context.runtime.build?.id`. That single rule cannot
+express both of the use cases the application needs:
+
+- **Catch-all files** — `/favicon.ico`, `/robots.txt`, `/site.webmanifest`. Their URLs
+  are fixed and un-namespaced, their content changes between builds, and they must be
+  revalidated on every use.
+- **Immutable build assets** — `/assets/<build-id>/stylesheets/stylesheet.css`. Their URLs
+  carry the Build ID, their content can never change for a given URL, and they should be
+  cached for a year without revalidation.
+
+The decisive difference is **where the namespace comes from**. The catch-all handler keeps
+taking it from the server (`context.runtime.build.id`), so a URL can never reach another
+build's files. The new asset handler takes it from the URL, which is what lets HTML cached
+by a browser or CDN keep fetching the exact assets it was rendered against after a new
+build is promoted. That inversion also makes the Build ID an untrusted input, so the
+asset handler must validate it with the same path-safety rule already applied to keys.
+
+Work lands in four sequential partitions: the framework handlers (Task 1), the Build ID
+placeholder that lets one URL shape work with and without a deployed build (Task 2), the
+application route and template wiring (Task 3), and dev server support so local
+development exercises the same URLs as production (Task 4).
+
+### Cross-cutting decisions
+
+These were settled with the user before planning and should not be re-litigated:
+
+1. **URL shape:** `/assets/:build_id/*pathname`. The route pattern extracts both parts;
+   the handler reads `request.pathnameParams` and never parses the raw pathname. This
+   keeps the URL shape owned by the route, and the resulting key
+   (`stylesheets/stylesheet.css`) is byte-identical to the key the publishing API writes
+   (`PUT /publishing-api/v1/assets/stylesheets/stylesheet.css`).
+2. **Stale Build IDs are served, not rejected.** A URL naming any build still present in
+   the store gets a 200. A pruned or unknown build gets a 404 from the ordinary store miss.
+   The handler never compares the URL's Build ID against the current one.
+3. **The catch-all handler is unchanged.** It keeps using the current Build ID as the
+   namespace and keeps its `public, max-age=0, must-revalidate` default, so an atomic
+   deploy still swaps `/favicon.ico`.
+4. **Immutable policy keeps validators.** `public, max-age=31536000, immutable`, and the
+   ETag / `Last-Modified` / 304 machinery stays on so a force-reloading client still gets
+   a cheap answer.
+5. **Names:** `StaticFileRequestHandler` (existing export, unchanged) and
+   `StaticAssetRequestHandler` (new). No breaking rename.
+6. **Untrusted Build ID:** validated as a safe path segment before it reaches the store —
+   400 when malformed, 404 when well-formed but absent.
+
+### Test strategy
+
+The user has explicitly asked for unit test coverage of this work, so writing **and running**
+the tests below is in scope for the tasks that own them. Follow `test/unit-tests/README.md`
+for the runner API, hook semantics, and mocking rules.
+
+Three facts set the shape of the coverage:
+
+- **`static-file-server-request-handlers.js` has no test file today.** Task 1 refactors the
+  existing handler's internals into helpers shared with a new handler, so the regression
+  coverage for `StaticFileRequestHandler` is not optional busywork — it is the only thing
+  that will prove the extraction did not change the behavior of the handler already serving
+  every static file in the application. Write those cases even though that handler's
+  observable behavior is meant to be unchanged.
+- **`src/virtual-hosts.js` and the templates are configuration and markup.** This project has
+  no unit test for the application's route table, and adding one would test the router, which
+  `test/unit-tests/kixx/http-router/` already covers. Task 3 relies on its manual checks.
+- **`tools/` has no test harness anywhere in the suite.** Task 4 is dev-only tooling and stays
+  manually verified.
+
+The new test file is `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`,
+mirroring the source tree per the guide. `test/unit-tests/kixx/hyperview/hyperview-request-handlers.test.js`
+is the closest existing model for request-handler tests — reuse its approach:
+
+- File-local `makeContext()`, `makeStore()`, `makeRequest()`, `makeResponse()`, and
+  `catchAsyncError()` factories rather than shared fixtures.
+- `makeResponse()` returns a real `ServerResponse` (`src/kixx/http-router/server-response.js`),
+  so tests assert on `response.status`, `response.headers.get(name)`, and `response.body`
+  instead of on a double's recorded calls.
+- The store double's `read` is a `MockTracker` mock, so the arguments the handler passes —
+  specifically `namespace` — are directly assertable. That matters more than the return value
+  here: the whole design rests on which namespace each handler chooses.
+- The result body double only needs a tracked `cancel()` method; the handlers never read it,
+  and a real `ReadableStream` would make the 304 and HEAD cancellation cases harder to assert.
+- Assert on `error.name` and `error.code`, never `instanceof` — the errors come from a
+  vendored module tree.
+
+### Known risk to keep in view
+
+Dropping the `{{#if build_id}}` conditional from the base templates (Task 3) means every
+deploy target must produce a servable `/assets/<segment>/...` URL, including a Node deploy
+that never sets `BUILD_ID`. Task 2's placeholder segment plus the handler's placeholder →
+flat-root mapping is what covers that case. If either half is skipped, an out-of-band
+deploy with no Build ID will 404 on every stylesheet.
+
+---
+
+### Task 1: Two static file request handlers with distinct lookup and cache rules
+
+**Status:** Complete
+**Depends on:** None
+**Documentation:** `src/kixx/static-file-server/README.md`, `src/docs/server-error-handling.md`, `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `test/unit-tests/README.md`
+
+**Objective**
+
+`src/kixx/static-file-server/static-file-server-request-handlers.js` exports two handler
+factories. `StaticFileRequestHandler` behaves exactly as it does today. A new
+`StaticAssetRequestHandler` reads the Build ID namespace and the store key from route
+params instead of from the runtime, and applies an immutable cache policy. The two share
+their response-mapping and conditional-request code rather than duplicating it.
+
+**Scope**
+
+- In: both factories, their shared internals, Build-ID-segment validation, the immutable
+  cache default, unit tests for both factories, the module README, and the Static File
+  Server Guide entry in `AGENTS.md`.
+- Out: route registration and templates (Task 3), the Build ID placeholder constant and
+  its Hyperview wiring (Task 2), dev server changes (Task 4), any change to the
+  `StaticFileStore` adapters or the interface contract.
+
+**Design and invariants**
+
+- `StaticFileRequestHandler` keeps its current name, option surface
+  (`contentType`, `cacheControl`, `computeEtag`, `throwNotFound`, `skipWhenFound`,
+  `pathname`), default `Cache-Control`, and behavior. Existing callers in
+  `src/virtual-hosts.js` and the README examples must not need edits.
+- `StaticAssetRequestHandler(options)` accepts:
+  - `contentType` — force the response `Content-Type`, as today.
+  - `cacheControl` — defaults to `public, max-age=31536000, immutable`.
+  - `computeEtag` — defaults to `true`.
+  - `buildIdParam` — pathname param holding the Build ID segment, defaults to `'build_id'`.
+  - `pathnameParam` — wildcard pathname param holding the key segments, defaults to `'pathname'`.
+- `StaticAssetRequestHandler` deliberately has **no** `throwNotFound`, `skipWhenFound`, or
+  `pathname` option. It is mounted on a dedicated route, so a miss is always a 404 and
+  there is never a later handler to fall through to. Do not add these options
+  speculatively.
+- **The asset handler must never read `context.runtime.build`.** The URL is the sole
+  source of the namespace. This is the property that makes previous-build assets
+  reachable; a "sanity check" against the current build would silently destroy it.
+- Input rules for the asset handler, in order:
+  1. `request.pathnameParams[buildIdParam]` must be a non-empty string, else
+     `BadRequestError`.
+  2. The Build ID segment goes through `validatePathname()` (`src/kixx/utils/validate-pathname.js`),
+     which rejects `..`, `//`, a leading `.`, and any character outside `[a-z0-9_.-]`.
+     This is the guard that keeps an attacker-chosen namespace from escaping the store root.
+  3. `request.pathnameParams[pathnameParam]` must be a non-empty array, else
+     `BadRequestError`.
+  4. The segments are joined with `/` and the joined key goes through `validatePathname()`.
+     Joining before validating is what makes an empty segment (`/assets/b1/css//main.css`)
+     a 400 — the joined string contains `//`. See the equivalent reasoning in
+     `src/app/presentation/request-handlers/publishing-api/route-params.js:139-153`.
+- **Case is preserved** in the key. Static asset reads resolve the stored key verbatim, so
+  folding case here would look for a file no write ever created. This matches
+  `getWildcardFilepath()` in the publishing API, which preserves case for exactly this reason.
+- A store miss throws `NotFoundError`. Per `src/docs/server-error-handling.md`, both a
+  malformed URL and an absent file are expected operational errors, not assertions.
+- Extract the shared tail of the current handler — `Cache-Control` / `ETag` /
+  `Last-Modified` header assignment, the `isNotModified()` 304 branch, the HEAD branch, and
+  the 200 stream response — into one module-private helper both factories call. Keep
+  `isNotModified`, `unquoteEtag`, `toEpochSeconds`, and `cancelBody` as the single shared
+  copies they already are. Do not fork this logic; a divergence between the two handlers'
+  conditional-request behavior would be a subtle cache bug.
+- Both factories get full JSDoc per `src/docs/code-documentation-guide.md`. The asset
+  handler's block must state that the namespace comes from the URL and that any still-stored
+  build is reachable.
+- The placeholder → flat-root mapping described in Task 2 is implemented **here**, in the
+  asset handler, but is written against the constant Task 2 introduces. If Task 1 lands
+  first, add the mapping in Task 2 rather than inventing a second constant.
+
+**Test coverage**
+
+New file: `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`,
+with one top-level `describe` and a nested `describe` per factory.
+
+`StaticFileRequestHandler` — regression coverage proving the refactor preserved today's behavior:
+
+- Passes the leading-slash-stripped pathname as `key` and the current `context.runtime.build.id` as `namespace`.
+- Passes `namespace: null` when the runtime has no build.
+- Forwards the `computeEtag` option to the store.
+- A request for `/` never calls the store and throws `NotFoundError`; with `throwNotFound: false` it returns the response untouched instead.
+- A store miss throws `NotFoundError`, or returns the response when `throwNotFound: false`.
+- The `pathname` option overrides the request URL when deriving the key.
+- The `contentType` option wins over the store's value; the store's value is used otherwise.
+- Sets `cache-control: public, max-age=0, must-revalidate` by default, and the override when given.
+- Calls `skip()` when `skipWhenFound: true` and a file is found, and does not when it is `false`.
+- A traversal pathname throws `BadRequestError` before the store is called.
+
+Shared response behavior — cover under whichever factory is cheaper to set up, and add one
+mirror case under the other so a future divergence in the shared helper is caught:
+
+- A hit responds 200 with the body, `content-type`, `content-length`, `etag`, and `last-modified`.
+- A matching `If-None-Match` responds 304 with validators, a null body, no `content-length`, and a cancelled body stream.
+- A non-matching `If-None-Match` responds 200 even when `If-Modified-Since` would have matched (RFC 9110 §13.2.2 precedence).
+- `If-Modified-Since` alone responds 304, including when the stored `lastModified` carries sub-second precision that the header cannot express.
+- A HEAD request responds 200 with `content-length` set, a null body, and a cancelled body stream.
+
+`StaticAssetRequestHandler`:
+
+- Resolves `namespace` from `pathnameParams.build_id` and `key` from the joined wildcard segments.
+- **Ignores `context.runtime.build.id` entirely** — give the context a *different* current build ID and assert the store received the URL's. This is the regression guard for the design's central decision; without it, a later "sanity check" against the current build could be added without any test failing.
+- Serves a stale Build ID: a URL naming a previous build reaches the store under that namespace and responds 200.
+- Preserves case in the key (`/assets/b1/CSS/Main.CSS` reads that exact key).
+- Missing or empty `build_id` param throws `BadRequestError`.
+- Malformed `build_id` (`..`, a leading dot, a space, an out-of-whitelist character) throws `BadRequestError` before the store is called.
+- Missing or empty wildcard pathname param throws `BadRequestError`.
+- An empty segment in the wildcard (joining to `//`) throws `BadRequestError`.
+- A traversal segment in the wildcard throws `BadRequestError`.
+- A store miss throws `NotFoundError`.
+- Sets `cache-control: public, max-age=31536000, immutable` by default, and honors an override.
+- Honors custom `buildIdParam` and `pathnameParam` option names.
+
+The placeholder → `null` namespace case is listed under Task 2, which introduces the constant.
+
+**Expected touch points**
+
+- `src/kixx/static-file-server/static-file-server-request-handlers.js` — both factories and shared internals.
+- `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js` — new test file covering both factories.
+- `src/kixx/static-file-server/README.md` — document the two handlers, when to reach for each, the immutable cache policy, the URL shape, and the stale-Build-ID behavior.
+- `AGENTS.md` — update the Static File Server Guide index entry so it names both handlers.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `StaticFileRequestHandler` is exported with unchanged behavior and options.
+- [ ] `StaticAssetRequestHandler` is exported and resolves namespace and key from `request.pathnameParams` only.
+- [ ] A missing or malformed Build ID segment produces a `BadRequestError` (400).
+- [ ] A missing or empty wildcard pathname produces a `BadRequestError` (400).
+- [ ] An empty path segment in the key produces a `BadRequestError` (400).
+- [ ] A well-formed URL whose namespace or key is absent from the store produces a `NotFoundError` (404).
+- [ ] A found asset responds 200 with `cache-control: public, max-age=31536000, immutable`, plus `ETag` and `Last-Modified` when the store supplies them.
+- [ ] `If-None-Match` and `If-Modified-Since` still produce a 304 with validators and no body; HEAD still produces headers with no body; both still cancel the body stream.
+- [ ] The 304 / HEAD / 200 response mapping exists once in the module and is shared by both factories.
+- [ ] Every case listed under **Test coverage** exists and passes.
+- [ ] A test asserts the asset handler reads the URL's Build ID while the context carries a different one.
+- [ ] The module README and the `AGENTS.md` index entry describe both handlers.
+
+**Validation**
+
+- `node run-linter.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/static-file-server/` — no lint errors.
+- `node run-tests.js test/unit-tests/kixx/static-file-server` — the new suite passes.
+- `node run-tests.js` — the full unit suite still passes, proving the shared-helper extraction broke no other caller.
+- Read-through check: confirm `context.runtime.build` appears in `StaticFileRequestHandler` only, never in `StaticAssetRequestHandler`.
+- Manual verification is deferred to Task 3, where the route exists to exercise these paths.
+
+**Progress and handoff**
+
+- Completed: Added `StaticAssetRequestHandler`, extracted the shared static-file response mapper, and added regression coverage for both handlers. Updated the static-file-server guide and its AGENTS index entry.
+- Current state: Complete.
+- Remaining: Task 2 must add the shared no-build placeholder and map it to the flat-root namespace.
+- Decisions and discoveries: `StaticAssetRequestHandler` reads only pathname params; `context.runtime.build` appears only in `StaticFileRequestHandler`. The placeholder-to-flat-root mapping remains intentionally deferred to Task 2 because its shared constant does not exist yet.
+- Actual files changed: `src/kixx/static-file-server/static-file-server-request-handlers.js`, `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`, `src/kixx/static-file-server/README.md`, `AGENTS.md`.
+- Validation run: `node run-linter.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/static-file-server/` (pass); `node run-tests.js test/unit-tests/kixx/static-file-server` (26 pass); `node run-tests.js` (1363 pass); read-through `rg` check confirms one runtime Build ID reference, in `StaticFileRequestHandler` only.
+- Blockers: None.
+
+---
+
+### Task 2: A Build ID placeholder so one asset URL shape works with or without a build
+
+**Status:** Complete
+**Depends on:** None
+**Documentation:** `src/templates/README.md`, `src/docs/code-style-guide.md`, `test/unit-tests/README.md`
+
+**Objective**
+
+The template context always exposes a usable `build_id` value, so base templates can emit a
+single `/assets/<build_id>/...` URL shape with no conditional, and that URL still resolves
+when the application is running with no `BUILD_ID` (local development and out-of-band
+deploys).
+
+**Scope**
+
+- In: the shared placeholder constant, the `metadata.build_id` assignment in
+  `HyperviewService`, the asset handler's placeholder → flat-root namespace mapping, and
+  unit tests for both behaviors.
+- Out: template edits (Task 3), dev server routing (Task 4), and any refactor of the
+  fourteen other `context.runtime.build?.id ?? null` call sites.
+
+**Design and invariants**
+
+- Add `src/kixx/utils/build-id.js` exporting `NO_BUILD_ID_SEGMENT = 'dev'`. A shared module
+  is the honest owner: the value is a URL-shape contract between the party that writes it
+  into the template context (Hyperview) and the party that reads it back off the URL (the
+  static asset handler). Neither module should own a constant the other depends on.
+- Do **not** add a `getCurrentBuildId(context)` helper in this task. The codebase already
+  uses the inline `context.runtime.build?.id ?? null` idiom in fourteen places; introducing
+  a second idiom used by one call site makes the code less consistent, not more.
+- `src/kixx/hyperview/hyperview-service.js:180` becomes
+  `metadata.build_id = buildId ?? NO_BUILD_ID_SEGMENT;`.
+- `StaticAssetRequestHandler` maps a Build ID segment equal to `NO_BUILD_ID_SEGMENT` to a
+  `null` namespace, which the stores already serve from their flat root
+  (`node-static-file-server/lib/static-file-server-store.js:97-99`). This is what keeps an
+  out-of-band, no-Build-ID Node deploy working once the templates lose their conditional.
+- **Consequence to record in the code:** `{{#if build_id}}` is now always truthy. Any
+  template that branches on it is dead-branching and must be updated (Task 3). The
+  `?.json` debug output for pages will show `"build_id": "dev"` in development rather than
+  `null`.
+- `'dev'` is a valid path segment under `validatePathname()`, so it survives the asset
+  handler's Build ID validation unchanged.
+
+**Test coverage**
+
+Add to `test/unit-tests/kixx/hyperview/hyperview-service.test.js`, in the `getPageMetadata`
+group. Its `makeContext(buildId = 'build-1')` factory already parameterizes the Build ID, and
+the existing case asserting `result.metadata.build_id === 'build-2'` already covers the
+real-build path — extend, do not rewrite:
+
+- `metadata.build_id` is the placeholder when `context.runtime.build.id` is `null`.
+- `metadata.build_id` is the placeholder when the runtime carries no `build` object at all
+  (`makeContext()` needs a variant that omits it). Both shapes reach production: `BUILD_ID`
+  unset yields `{ id: undefined }`, and a command runtime may have no `build` key.
+- Assert against the imported constant, not the literal `'dev'`, so changing the placeholder
+  is a one-line change rather than a test hunt.
+
+Add to `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`
+(created in Task 1), in the `StaticAssetRequestHandler` group:
+
+- A URL whose Build ID segment equals the placeholder calls the store with `namespace: null`.
+- A URL with any other Build ID passes that literal value through, so the mapping is narrow
+  and does not accidentally swallow a real build named something similar.
+
+No test for `src/kixx/utils/build-id.js` itself. It exports one string constant with no
+behavior; a test asserting `'dev' === 'dev'` documents nothing and only pins the value in a
+second place.
+
+**Expected touch points**
+
+- `src/kixx/utils/build-id.js` — new module holding the placeholder constant.
+- `src/kixx/hyperview/hyperview-service.js` — default `metadata.build_id` to the placeholder.
+- `src/kixx/static-file-server/static-file-server-request-handlers.js` — map the placeholder to a null namespace.
+- `test/unit-tests/kixx/hyperview/hyperview-service.test.js` — placeholder cases for the absent-build paths.
+- `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js` — placeholder namespace mapping cases.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `NO_BUILD_ID_SEGMENT` is exported from one module and imported by both consumers.
+- [ ] With `BUILD_ID` set, `metadata.build_id` is the real Build ID.
+- [ ] With `BUILD_ID` unset, `metadata.build_id` is the placeholder rather than `null`.
+- [ ] `StaticAssetRequestHandler` reads the placeholder segment as a `null` namespace (flat store root) and any other segment as that literal namespace.
+- [ ] An inline comment at the `metadata.build_id` assignment explains why a placeholder is used instead of `null`.
+- [ ] Every case listed under **Test coverage** exists and passes, asserting against the imported constant rather than the literal.
+
+**Validation**
+
+- `node run-linter.js src/kixx/utils/build-id.js src/kixx/hyperview/hyperview-service.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/` — no lint errors.
+- `node run-tests.js test/unit-tests/kixx/hyperview test/unit-tests/kixx/static-file-server` — both suites pass.
+- `node run-tests.js` — the full unit suite still passes; the `build_id` default changes a value other Hyperview tests read.
+- Manual (after Task 3): `curl -s http://localhost:2026/index.json | grep build_id` reports the placeholder in development.
+
+**Progress and handoff**
+
+- Completed: Added the shared `NO_BUILD_ID_SEGMENT` constant; Hyperview now emits it when a runtime has no Build ID; and the asset handler maps precisely that segment to the flat store root. Added the required tests.
+- Current state: Complete.
+- Remaining: Task 3 must register the route and emit the asset URL shape in base templates.
+- Decisions and discoveries: The placeholder is `dev`, a valid safe pathname segment. The metadata assignment includes the required rationale comment; `build_id` is now always truthy.
+- Actual files changed: `src/kixx/utils/build-id.js`, `src/kixx/hyperview/hyperview-service.js`, `src/kixx/static-file-server/static-file-server-request-handlers.js`, `test/unit-tests/kixx/hyperview/hyperview-service.test.js`, `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`.
+- Validation run: `node run-linter.js src/kixx/utils/build-id.js src/kixx/hyperview/hyperview-service.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/` (pass); `node run-tests.js test/unit-tests/kixx/hyperview test/unit-tests/kixx/static-file-server` (138 pass); `node run-tests.js` (1366 pass).
+- Blockers: None.
+
+---
+
+### Task 3: Serve and reference build assets at /assets/:build_id/*pathname
+
+**Status:** Complete
+**Depends on:** Task 1, Task 2
+**Documentation:** `src/app/presentation/README.md`, `src/templates/README.md`, `src/docs/frontend-development-guide.md`
+
+**Objective**
+
+The application serves `/assets/<build-id>/<key>` through `StaticAssetRequestHandler`, and
+every base template references its stylesheet and script through that URL shape with no
+conditional fallback.
+
+**Scope**
+
+- In: the new route in `src/virtual-hosts.js`, and the asset URLs in the three base templates.
+- Out: framework handler behavior (Task 1), the placeholder constant (Task 2), dev server
+  interception (Task 4), page-local `page_stylesheet` includes (inlined, unaffected), and
+  unit tests (see **Test coverage** below).
+
+**Design and invariants**
+
+- The route is declared **before** the `'*'` catch-all in `src/virtual-hosts.js:99`. Routes
+  match in declaration order, so a later declaration would let the catch-all
+  `StaticFileRequestHandler` swallow `/assets/**` and look the whole path up as a key under
+  the current build — the exact double-namespacing bug this work exists to remove.
+- Route shape:
+  ```js
+  {
+      pattern: '/assets/:build_id/*pathname',
+      name: 'build-assets',
+      targets: [
+          {
+              name: 'serve-asset',
+              methods: [ 'GET', 'HEAD' ],
+              requestHandlers: [ StaticAssetRequestHandler() ],
+          },
+      ],
+  },
+  ```
+- No `errorHandlers` on the route: a 404 for a missing asset should fall through to the
+  virtual host's existing handling, the same as any other unmatched resource.
+- Template edits — drop the `{{#if build_id}}` / `{{ else }}` blocks entirely and emit:
+  - `src/templates/base/default.html:10-14` → `/assets/{{ build_id }}/stylesheets/stylesheet.css`
+  - `src/templates/base/default.html:36-40` → `/assets/{{ build_id }}/javascript/site.js`
+  - `src/templates/base/admin.html:9-13` → `/assets/{{ build_id }}/stylesheets/admin.css`
+  - `src/templates/base/admin-login.html:9-13` → `/assets/{{ build_id }}/stylesheets/admin.css`
+  Note the Build ID moves **before** the `stylesheets/` and `javascript/` segments; the old
+  URLs put it in the middle, which no route could map back onto a stored key.
+- Keep the existing explanatory template comment, updated to say that the Build ID segment
+  namespaces the asset and enables the immutable cache policy.
+- **Coordinated change point:** the resulting store keys are `stylesheets/stylesheet.css`,
+  `stylesheets/admin.css`, and `javascript/site.js`. Deploy tooling must publish assets at
+  exactly those keys via `PUT /publishing-api/v1/assets/<key>` with a staged
+  `Kixx-Build-Id`. Note this in the module README if it is not already stated.
+
+**Test coverage**
+
+No unit tests. `src/virtual-hosts.js` is the application's route table and the base templates
+are markup; the suite has no precedent for testing either, and a test asserting that a route
+entry exists would restate the file rather than verify behavior. Route matching itself is
+already covered by `test/unit-tests/kixx/http-router/`, and the handler this route mounts is
+covered by Task 1.
+
+The gap this leaves is real and worth naming: nothing automated proves the route is declared
+*ahead* of the `'*'` catch-all, which is the one ordering mistake that would silently
+reintroduce double-namespacing. The manual checks below are what catch it. If this ever needs
+automating, it belongs in `test/end-to-end/` alongside the existing publishing-API suites,
+which exercise a running server — not in the unit suite.
+
+**Expected touch points**
+
+- `src/virtual-hosts.js` — import `StaticAssetRequestHandler` and add the route above the catch-all.
+- `src/templates/base/default.html` — stylesheet and script URLs.
+- `src/templates/base/admin.html` — stylesheet URL.
+- `src/templates/base/admin-login.html` — stylesheet URL.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `/assets/:build_id/*pathname` is registered ahead of the `'*'` catch-all and serves GET and HEAD.
+- [ ] All three base templates emit the new URL shape with no `{{#if build_id}}` branch.
+- [ ] No template still references `/stylesheets/` or `/javascript/` directly.
+- [ ] `/favicon.ico` and the other root files still resolve through the catch-all handler.
+- [ ] The store keys implied by the templates match what the publishing API writes.
+
+**Validation**
+
+- `node run-linter.js src/virtual-hosts.js` — no lint errors.
+- `node run-tests.js` — the full unit suite still passes.
+- Manual, with the dev server running (`node tools/devserver.js --port 2026`):
+  - `curl -sI http://localhost:2026/favicon.ico` → 200 with `cache-control: public, max-age=0, must-revalidate`.
+  - `curl -s http://localhost:2026/ | grep -E 'stylesheet|site.js'` → both tags carry the `/assets/dev/...` shape.
+  - `curl -sI 'http://localhost:2026/assets/dev/../../etc/passwd'` → 400.
+  - `curl -sI http://localhost:2026/assets/dev/stylesheets/nope.css` → 404.
+- Manual, against a deployed build (cannot be run locally): request an asset under the
+  previous build's ID after a promotion and confirm a 200 with the immutable
+  `Cache-Control`, then confirm `If-None-Match` with the returned ETag gives a 304.
+
+**Progress and handoff**
+
+- Completed: Registered the build-asset GET/HEAD route before the static catch-all and migrated all base-template stylesheet and module-script URLs to `/assets/{{ build_id }}/<key>` without conditional branches.
+- Current state: Complete, except for the plan's dev-server manual checks, which were not run because the repository instructions prohibit dev-server/smoke verification unless explicitly requested.
+- Remaining: Task 4 must intercept these URLs in the development-server source-file handlers.
+- Decisions and discoveries: Both admin templates also contained a direct script URL, so they were migrated along with the explicitly listed stylesheet URLs to satisfy the no-direct-asset-URL invariant.
+- Actual files changed: `src/virtual-hosts.js`, `src/templates/base/default.html`, `src/templates/base/admin.html`, `src/templates/base/admin-login.html`.
+- Validation run: `node run-linter.js src/virtual-hosts.js` (pass); `node run-tests.js` (1366 pass); read-through checks confirm the asset route is before `'*'` and no template has direct stylesheet/script URLs or `{{#if build_id}}`.
+- Blockers: Manual dev-server and deployed-build checks deferred by repository verification policy.
+- Blockers: None.
+
+---
+
+### Task 4: Dev server support for the /assets URL shape
+
+**Status:** Complete
+**Depends on:** Task 3
+**Documentation:** `README.md` (Development Server), `AGENTS.md` (Development Server)
+
+**Objective**
+
+Local development exercises the same `/assets/<segment>/...` URLs as production while
+still reading CSS and JavaScript straight from `src/stylesheets/` and `src/javascript/`,
+so an edit shows up on the next reload with no build step and no server restart.
+
+**Scope**
+
+- In: dev server interception of `/assets/**`, and the README/AGENTS notes describing it.
+- Out: setting `BUILD_ID` on the child process (see below), any change to the app server's
+  own handlers, any asset build or bundling step, and unit tests (see **Test coverage** below).
+
+**Design and invariants**
+
+- **Do not set `BUILD_ID` on the app server child to make this work.** The same Build ID
+  namespaces the page data store, the template file store, and the Hyperview page cache, so
+  a synthetic Build ID in development would send every page lookup to
+  `src/pages/<build-id>/` and 404 the entire site. The dev server must fake the Build ID at
+  the URL layer only, which is exactly what Task 2's placeholder allows.
+- The dev server strips the `/assets/` prefix **and the following Build ID segment**,
+  whatever its value, then dispatches the remainder to the existing source-file handlers:
+  a remaining path under `stylesheets/` is served from `src/stylesheets/`, and one under
+  `javascript/` from `src/javascript/`. The segment's value is ignored entirely — there is
+  no build to distinguish in development.
+- Keep the existing bare `/stylesheets/` and `/javascript/` prefixes working. They cost
+  nothing, and they stay useful for opening a source file directly in a browser.
+- Reuse `validatePathname()` and the existing resolved-path root check in
+  `tools/devserver/stylesheet-file-handler.js:44-60` rather than writing a third copy of the
+  traversal guard.
+- **Dev must keep responding `cache-control: no-cache`.** The production handler now sends
+  a one-year immutable policy; if the dev server ever echoed that, an edited stylesheet
+  would be invisible for a year behind the browser cache. This is the single most important
+  behavioral difference between the two paths.
+- Interception happens before the proxy hop, alongside the existing checks in
+  `tools/devserver.js:64-88`, so an asset request never restarts or waits on the app
+  server child.
+
+**Test coverage**
+
+No unit tests. Nothing under `tools/` is covered by the unit suite today, and the dev server's
+behavior is defined by Node `http` request and response objects that would need substantial
+faking to assert against — the harness cost would exceed the value for code that never ships
+to a deploy target. The manual checks below are the verification for this task; run all of
+them, including the edit-and-reload check, since the caching mistake this task guards against
+is invisible to a single `curl`.
+
+If coverage here ever becomes worthwhile, the testable seam is the prefix-stripping function
+(pathname in, `{ root, key }` or `null` out), which is pure and could be extracted and tested
+without touching the HTTP layer. Do not extract it speculatively as part of this task.
+
+**Expected touch points**
+
+- `tools/devserver/stylesheet-file-handler.js` and/or `tools/devserver/javascript-file-handler.js` — accept the `/assets/<segment>/` prefixed form, or expose the pieces a shared matcher needs.
+- `tools/devserver.js` — dispatch `/assets/**` to the source-file handlers.
+- `README.md` and `AGENTS.md` — note that the dev server serves the `/assets/**` shape from source and ignores the Build ID segment.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the
+actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] `/assets/dev/stylesheets/stylesheet.css` is served from `src/stylesheets/stylesheet.css` without proxying to the app server.
+- [ ] `/assets/dev/javascript/site.js` is served from `src/javascript/site.js`.
+- [ ] Any Build ID segment value works identically in development.
+- [ ] The bare `/stylesheets/**` and `/javascript/**` prefixes still work.
+- [ ] Dev responses carry `cache-control: no-cache`, never the immutable policy.
+- [ ] A traversal attempt under `/assets/**` is a 400, and a missing file is a 404.
+- [ ] Non-GET/HEAD methods still produce 405 with an `Allow` header.
+
+**Validation**
+
+- `node run-linter.js tools/devserver.js tools/devserver/` — no lint errors.
+- Manual, with `node tools/devserver.js --port 2026` running:
+  - `curl -sI http://localhost:2026/assets/dev/stylesheets/stylesheet.css` → 200, `content-type: text/css`, `cache-control: no-cache`.
+  - `curl -sI http://localhost:2026/assets/anything/javascript/site.js` → 200.
+  - `curl -sI http://localhost:2026/stylesheets/stylesheet.css` → 200 (legacy prefix still works).
+  - `curl -sI 'http://localhost:2026/assets/dev/stylesheets/../../../package.json'` → 400.
+  - `curl -sI -X POST http://localhost:2026/assets/dev/stylesheets/stylesheet.css` → 405.
+  - Load `http://localhost:2026/` in a browser, edit a rule in `src/stylesheets/stylesheet.css`, reload, and confirm the change appears without restarting the dev server.
+
+**Progress and handoff**
+
+- Completed: Added development-server interception for `/assets/<segment>/stylesheets/**` and `/assets/<segment>/javascript/**`, stripping the URL envelope before dispatching to existing source-file handlers. Documented the behavior in both development-server guides.
+- Current state: Complete, except for the plan's dev-server manual checks, which were not run because repository instructions prohibit dev-server/smoke verification unless explicitly requested.
+- Remaining: None.
+- Decisions and discoveries: The raw request path is used before dispatch so `validatePathname()` can reject dot-segment traversal instead of URL normalization collapsing it first. Existing source-file handlers retain the root check, `no-cache`, 404, and 405 behavior; bare source prefixes remain unchanged.
+- Actual files changed: `tools/devserver.js`, `README.md`, `AGENTS.md`.
+- Validation run: `node run-linter.js tools/devserver.js tools/devserver/` (pass); `git diff --check` (pass).
+- Blockers: Manual curl/browser checks deferred by repository verification policy.
+- Blockers: None.

--- a/docs/publishing-api-v1.md
+++ b/docs/publishing-api-v1.md
@@ -5,7 +5,9 @@ assets into a Kixx build. This reference describes the HTTP contract for
 developers implementing a client or SDK.
 
 The API is write-only. Version 1 does not expose operations to read, list,
-delete, or promote published resources.
+delete, or promote published resources. Published static assets are served
+publicly at build-addressed URLs outside this API — see
+[Reading a published asset](#reading-a-published-asset).
 
 ## Base path
 
@@ -27,10 +29,17 @@ Examples in this document use `https://example.com` as the deployment origin.
 | `PUT` | `/pages/{pathname}` | JSON:API page metadata | Named build or current build |
 | `PUT` | `/pages` or `/pages/` | JSON:API root-page metadata | Named build or current build |
 | `PUT` | `/includes/{filepath}` | Page include source | Named build or current build |
-| `PUT` | `/assets/{filepath}` | Raw asset bytes | Staged build only |
+| `PUT` | `/assets/{filepath}` | Raw asset bytes | Staged build only, write-once |
 
-Every endpoint uses replacement semantics. Repeating a successful request for
-the same resource and build replaces the previous value and returns `200 OK`.
+Template, page metadata, and include writes use replacement semantics. Repeating
+a successful request for the same resource and build replaces the previous value
+and returns `200 OK`.
+
+Static asset writes are write-once instead. The first successful `PUT` fixes the
+bytes and stored media type at a given build ID and filepath. Repeating that
+request unchanged returns `200 OK` without rewriting anything, while publishing
+different content at the same address returns
+`409 StaticAssetImmutableConflict`. See [Write-once addresses](#write-once-addresses).
 
 ## Authentication and authorization
 
@@ -60,8 +69,10 @@ The optional or required build header is:
 Kixx-Build-Id: <build-id>
 ```
 
-Header names are case-insensitive. Client libraries should treat build IDs as
-opaque strings.
+Header names are case-insensitive. A client should treat the *meaning* of a
+build ID as opaque, but its form is not free-form: a build ID appears as a path
+segment in public asset URLs and as a storage namespace, so it must satisfy the
+format rules below.
 
 The endpoints use two different build policies:
 
@@ -78,6 +89,38 @@ The endpoints use two different build policies:
   its first staged build.
 
 The effective build ID is returned in every successful response.
+
+### Build ID format
+
+A build ID must be a single, safe URL path segment. It must:
+
+- be a non-empty string;
+- contain only the characters `A-Z a-z 0-9 _ . -`;
+- contain no `/`, so a build ID is never more than one segment;
+- not begin with `.`, and not contain `..`;
+- not be exactly the lowercase value `dev`.
+
+Build IDs are case-sensitive and are stored and echoed back exactly as supplied.
+Only the exact lowercase `dev` is reserved; `DEV` is an ordinary valid build ID.
+The reserved value names the flat, un-namespaced asset root used by deployments
+that run without a build ID, so no build may publish into it.
+
+| Status | Code | Condition |
+|---|---|---|
+| `400` | `ReservedBuildId` | Build ID is exactly `dev` |
+| `400` | `InvalidBuildId` | Build ID is not one safe, non-empty path segment |
+
+Every endpoint applies these rules, including those that do not require the
+header. For page metadata and includes the rules are applied to the *effective*
+build ID, so a supplied header is validated identically whether or not the
+endpoint required one. A deployment's own current build ID is validated when the
+server starts, so the omitted-header fallback cannot produce these errors
+against a running deployment.
+
+These checks run after the endpoint's existing requiredness check. A missing
+header still reports `BuildIdRequired` on templates and assets, and still
+reports `CurrentBuildIdRequired` on pages and includes when the deployment has
+no current build.
 
 ### Live include visibility
 
@@ -227,6 +270,8 @@ Status: `200 OK`
 | Status | Code | Condition |
 |---|---|---|
 | `400` | `BuildIdRequired` | `Kixx-Build-Id` is missing or empty |
+| `400` | `ReservedBuildId` | `Kixx-Build-Id` is the reserved value `dev` |
+| `400` | `InvalidBuildId` | `Kixx-Build-Id` is not one safe path segment |
 | `400` | `TemplateSourceRequired` | Body text is empty |
 | `400` | `EmptyPathSegment` | Filepath contains an empty segment |
 | `400` | `BAD_REQUEST_ERROR` | Filepath violates the path character or traversal rules |
@@ -341,6 +386,8 @@ build ID appears in resource-level `meta`, not in `attributes`.
 |---|---|---|
 | `400` | `BAD_REQUEST_ERROR` | Invalid JSON, malformed JSON:API envelope, or invalid pathname |
 | `400` | `EmptyPathSegment` | Non-root pathname contains an empty segment |
+| `400` | `ReservedBuildId` | `Kixx-Build-Id` is the reserved value `dev` |
+| `400` | `InvalidBuildId` | `Kixx-Build-Id` is not one safe path segment |
 | `400` | `InvalidPageIncludes` | `attributes.includes` is present but is not an object |
 | `400` | `InvalidIncludeFilename` | An include filename is missing, invalid, or not lowercase |
 | `409` | `JsonApiResourceTypeMismatch` | `data.type` is not `PageMetadata` |
@@ -424,6 +471,8 @@ Status: `200 OK`
 | `400` | `IncludeSourceRequired` | Body text is empty |
 | `400` | `EmptyPathSegment` | Filepath contains an empty segment |
 | `400` | `BAD_REQUEST_ERROR` | Filepath violates the path character or traversal rules |
+| `400` | `ReservedBuildId` | `Kixx-Build-Id` is the reserved value `dev` |
+| `400` | `InvalidBuildId` | `Kixx-Build-Id` is not one safe path segment |
 | `409` | `CurrentBuildIdRequired` | Header is omitted and the deployment has no current build |
 | `415` | `UNSUPPORTED_MEDIA_TYPE_ERROR` | Media type does not begin with `text/` |
 
@@ -480,7 +529,71 @@ Status: `200 OK`
 ```
 
 `contentLength` is the number of stored bytes. `etag` is a strong, quoted ETag
-derived from the SHA-256 digest of those bytes.
+derived from the SHA-256 digest of those bytes. An identical retry returns this
+same document describing the already-stored asset.
+
+### Write-once addresses
+
+A static asset address is the pair of build ID and filepath. The first
+successful `PUT` fixes that address for the life of the build. A later `PUT` to
+the same address is compared against the stored asset on three values:
+
+- the strong ETag of the request body — the quoted SHA-256 digest of the bytes;
+- the byte length of the request body;
+- the normalized media type, lowercased and with parameters removed.
+
+When all three match, the request is an identical retry: the API returns
+`200 OK` with the stored asset's parts and does not rewrite it. This is what
+makes replaying a request after a network failure safe.
+
+When any of them differs — or the stored asset carries no strong ETag for the
+server to compare against — the API returns `409 StaticAssetImmutableConflict`
+and leaves the stored asset untouched. Changed output must be published under a
+new build ID.
+
+Immutability is a **sequential** guarantee only. The server reads the address
+before writing, but performs no atomic create-only operation, so two concurrent
+first writes to the same address can both observe an absent asset and race.
+Clients must serialize writes to a single build ID and filepath. Concurrent
+writes to *different* addresses are supported.
+
+The comparison is reached only after every earlier check passes. A `PUT`
+targeting the current build still returns `CurrentBuildWriteConflict` even when
+its bytes match what is stored.
+
+### Reading a published asset
+
+Published assets are served outside the Publishing API at:
+
+```http
+GET /assets/{build-id}/{filepath}
+```
+
+`{filepath}` is exactly the filepath used to publish the asset. The published
+filepath never includes the `/assets/` prefix or the build ID; the read URL adds
+both:
+
+```text
+PUT /publishing-api/v1/assets/stylesheets/stylesheet.css
+Kixx-Build-Id: build-2026-07-29
+
+GET /assets/build-2026-07-29/stylesheets/stylesheet.css
+```
+
+The URL carries the build ID, so an asset staged for a build that has not been
+promoted is publicly readable as soon as it is written, and an asset belonging
+to a previous build stays readable while that build's files remain in the store.
+Reads never consult the deployment's current build.
+
+Responses use `Cache-Control: public, max-age=31536000, immutable` alongside
+`ETag` and `Last-Modified` validators. That cache policy is the reason the write
+path is write-once: a URL already handed to a browser or CDN must never change
+its bytes.
+
+The filepath is used exactly as published, including case. The reserved `dev`
+segment (`GET /assets/dev/{filepath}`) reads the flat, un-namespaced root used
+by deployments running without a build ID; it is not a build and cannot be
+published to.
 
 ### Asset-specific errors
 
@@ -488,11 +601,19 @@ derived from the SHA-256 digest of those bytes.
 |---|---|---|
 | `400` | `ContentTypeRequired` | `Content-Type` is missing or empty |
 | `400` | `BuildIdRequired` | `Kixx-Build-Id` is missing or empty |
+| `400` | `ReservedBuildId` | `Kixx-Build-Id` is the reserved value `dev` |
+| `400` | `InvalidBuildId` | `Kixx-Build-Id` is not one safe path segment |
 | `400` | `StaticAssetSourceRequired` | Body has zero bytes |
 | `400` | `EmptyPathSegment` | Filepath contains an empty segment |
 | `400` | `BAD_REQUEST_ERROR` | Filepath violates the path character or traversal rules |
 | `409` | `CurrentBuildWriteConflict` | Build ID is the current build |
+| `409` | `StaticAssetImmutableConflict` | Address already holds different bytes or a different content type |
 | `413` | `PAYLOAD_TOO_LARGE_ERROR` | Body exceeds 24 MiB |
+
+Asset checks run in a fixed order, so a request with more than one problem
+reports the first one reached: filepath, `Content-Type`, body size, body bytes,
+build ID presence, build ID format, current-build conflict, and finally the
+write-once comparison.
 
 ## Error documents
 
@@ -572,13 +693,22 @@ over time.
 - Require a build ID in the SDK method signature for templates and assets.
 - Make the build ID optional for page metadata and includes, while clearly
   labeling omission as a live-build edit.
+- Validate build IDs locally against the single-safe-segment rule, and reject
+  `dev`, before sending a request. A generated build ID that fails these rules
+  fails every publish in a deploy, so catching it once at the source is cheaper
+  than reading `InvalidBuildId` off each response.
 - Canonicalize template, page, and include paths to lowercase before using them
   as local cache keys. Do not lowercase asset paths.
 - Serialize page metadata as JSON:API and omit request `data.id`; use the URL as
   the resource identity.
 - Preserve response build IDs instead of assuming the requested ID, especially
   when a page or include request omitted the header.
-- Model every operation as an idempotent replacement, not a patch or create.
+- Model template, page metadata, and include operations as idempotent
+  replacements, never as patches or creates.
+- Model asset operations as idempotent write-once publishes. Serialize uploads
+  to the same build ID and filepath, treat an identical retry as success, and
+  treat `StaticAssetImmutableConflict` as a signal that the build ID must change
+  rather than as a transient failure worth retrying.
 - Parse JSON:API error arrays even when most failures contain only one error.
 - Do not automatically retry `401`, `403`, `409`, `413`, `415`, or `422`
   responses. A retry requires changed credentials, request data, or build state.

--- a/src/app/presentation/request-handlers/publishing-api/route-params.js
+++ b/src/app/presentation/request-handlers/publishing-api/route-params.js
@@ -72,7 +72,7 @@ export function getWildcardFilepath(request, name, { label, requiredCode }) {
     // segments as the client sent them so the error message echoes the request.
     //
     // The case is deliberately preserved: unlike page pathnames, static asset
-    // reads resolve the key verbatim (StaticFileRequestHandler looks the URL
+    // reads resolve the key verbatim (StaticAssetRequestHandler looks the URL
     // pathname up as sent), so folding here would store the file under a name no
     // read ever asks for. Template writes need the opposite and wrap this
     // function — see getWildcardTemplateFilepath() below.

--- a/src/app/transaction-scripts/publishing/put-include.js
+++ b/src/app/transaction-scripts/publishing/put-include.js
@@ -1,5 +1,6 @@
 import { isNonEmptyString } from '../../../kixx/assertions/mod.js';
 import { AssertionError, BadRequestError, ConflictError } from '../../../kixx/errors/mod.js';
+import { validateBuildId } from '../../../kixx/utils/build-id.js';
 
 
 /**
@@ -43,6 +44,8 @@ export async function putInclude(context, args) {
             code: 'CurrentBuildIdRequired',
         });
     }
+
+    validateBuildId(effectiveBuildId);
 
     const service = context.getService('Hyperview');
 

--- a/src/app/transaction-scripts/publishing/put-page-metadata.js
+++ b/src/app/transaction-scripts/publishing/put-page-metadata.js
@@ -1,5 +1,6 @@
 import { isNonEmptyString } from '../../../kixx/assertions/mod.js';
 import { AssertionError, ConflictError } from '../../../kixx/errors/mod.js';
+import { validateBuildId } from '../../../kixx/utils/build-id.js';
 
 
 /**
@@ -31,6 +32,8 @@ export async function putPageMetadata(context, args) {
             code: 'CurrentBuildIdRequired',
         });
     }
+
+    validateBuildId(effectiveBuildId);
 
     const service = context.getService('Hyperview');
 

--- a/src/app/transaction-scripts/publishing/put-static-asset.js
+++ b/src/app/transaction-scripts/publishing/put-static-asset.js
@@ -4,6 +4,8 @@ import {
     BadRequestError,
     ConflictError,
 } from '../../../kixx/errors/mod.js';
+import { validateBuildId } from '../../../kixx/utils/build-id.js';
+import { computeStaticFileEtag } from '../../../kixx/static-file-server/static-file-etag.js';
 
 
 /**
@@ -17,8 +19,8 @@ import {
  * @returns {Promise<{ filepath: string, buildId: string, contentType: string, contentLength: number, etag: string }>}
  *   The written asset's parts.
  * @throws {BadRequestError} When the body is empty or the buildId is missing.
- * @throws {ConflictError} When buildId targets the current build.
- * @throws {AssertionError} When the store write unexpectedly fails.
+ * @throws {ConflictError} When buildId targets the current build or an existing asset differs.
+ * @throws {AssertionError} When static-file store access unexpectedly fails.
  */
 export async function putStaticAsset(context, args) {
     const {
@@ -42,6 +44,8 @@ export async function putStaticAsset(context, args) {
         });
     }
 
+    validateBuildId(buildId);
+
     // Asset writes are staged-only: they must target a build other than the live
     // one so the current asset set stays immutable until an atomic promotion. A
     // missing current build id (site never deployed) lets the first deploy stage
@@ -55,7 +59,45 @@ export async function putStaticAsset(context, args) {
         });
     }
 
+    const etag = await computeStaticFileEtag(body);
     const store = context.getService('StaticFileStore');
+
+    let existing;
+    try {
+        existing = await store.read(context, {
+            key: filepath,
+            namespace: buildId,
+            computeEtag: true,
+        });
+    } catch (cause) {
+        throw new AssertionError('Unexpected error while reading an existing static asset', { cause });
+    }
+
+    if (existing) {
+        try {
+            await cancelBody(existing.body);
+        } catch (cause) {
+            throw new AssertionError('Unexpected error while cancelling an existing static asset body', { cause });
+        }
+
+        if (existing.etag === etag
+            && existing.contentLength === body.byteLength
+            && existing.contentType === contentType) {
+            return {
+                filepath,
+                buildId,
+                contentType: existing.contentType,
+                contentLength: existing.contentLength,
+                etag: existing.etag,
+            };
+        }
+
+        // This is only a sequential guarantee: concurrent first writers can both
+        // observe a miss, so publishing clients must serialize one asset address.
+        throw new ConflictError('Static asset address already exists with different content or content type.', {
+            code: 'StaticAssetImmutableConflict',
+        });
+    }
 
     let written;
     try {
@@ -76,4 +118,10 @@ export async function putStaticAsset(context, args) {
         contentLength: written.contentLength,
         etag: written.etag,
     };
+}
+
+async function cancelBody(body) {
+    if (body) {
+        await body.cancel();
+    }
 }

--- a/src/app/transaction-scripts/publishing/put-template.js
+++ b/src/app/transaction-scripts/publishing/put-template.js
@@ -4,6 +4,7 @@ import {
     BadRequestError,
     ConflictError,
 } from '../../../kixx/errors/mod.js';
+import { validateBuildId } from '../../../kixx/utils/build-id.js';
 
 
 const TEMPLATE_KINDS = new Set([ 'base', 'page', 'partial' ]);
@@ -46,6 +47,8 @@ export async function putTemplate(context, args) {
             code: 'BuildIdRequired',
         });
     }
+
+    validateBuildId(buildId);
 
     // A missing current build id means the site has never been deployed; the
     // first deploy must be able to stage its templates. The equality check below

--- a/src/kixx/context/app-runtime.js
+++ b/src/kixx/context/app-runtime.js
@@ -7,8 +7,10 @@ import {
     AssertionError,
     assertNonEmptyString,
     isObjectNotNull,
+    isUndefined,
 } from '../assertions/mod.js';
 import deepFreeze from '../utils/deep-freeze.js';
+import { isValidBuildId } from '../utils/build-id.js';
 
 
 /**
@@ -66,6 +68,10 @@ export default class AppRuntime {
         }
 
         if (build) {
+            if (!isUndefined(build.id) && build.id !== null && !isValidBuildId(build.id)) {
+                throw new AssertionError('AppRuntime build id must be a valid Build ID');
+            }
+
             Object.defineProperty(this, 'build', {
                 enumerable: true,
                 value: deepFreeze(build),

--- a/src/kixx/hyperview/hyperview-service.js
+++ b/src/kixx/hyperview/hyperview-service.js
@@ -1,5 +1,6 @@
 import * as templating from '../templating/mod.js';
 import deepMerge from '../utils/deep-merge.js';
+import { NO_BUILD_ID_SEGMENT } from '../utils/build-id.js';
 import {
     assert,
     assertNonEmptyString,
@@ -177,7 +178,9 @@ export default class HyperviewService {
 
         const metadata = deepMerge(...mergeItems);
 
-        metadata.build_id = buildId;
+        // Templates need a non-empty segment for one stable asset URL shape; the
+        // asset handler maps this placeholder back to the flat store root.
+        metadata.build_id = buildId ?? NO_BUILD_ID_SEGMENT;
 
         return { version, metadata };
     }

--- a/src/kixx/static-file-server/README.md
+++ b/src/kixx/static-file-server/README.md
@@ -142,7 +142,7 @@ import { StaticAssetRequestHandler } from './kixx/static-file-server/static-file
 }
 ```
 
-This handler uses `public, max-age=31536000, immutable` by default while still supplying ETag and Last-Modified validators for force reloads. It validates the Build ID and wildcard path before reading the store: malformed input is a 400, and a well-formed asset absent from the named namespace is a 404. Asset upload keys must omit the URL prefix and Build ID — for example, publishing `stylesheets/stylesheet.css` produces the URL `/assets/<build-id>/stylesheets/stylesheet.css`.
+This handler uses `public, max-age=31536000, immutable` by default while still supplying ETag and Last-Modified validators for force reloads. It serves any stored Build ID namespace — staged, current, or historical — rather than only the runtime's current build. A real Build ID is one safe URL segment and cannot equal the reserved lowercase `dev` placeholder, which maps only asset reads to the flat no-build root. Malformed input is a 400, and a well-formed asset absent from the named namespace is a 404. Asset upload keys must omit the URL prefix and Build ID — for example, publishing `stylesheets/stylesheet.css` produces the URL `/assets/<build-id>/stylesheets/stylesheet.css`.
 
 ## How Static File Serving Works
 
@@ -168,9 +168,11 @@ When deploying to Cloudflare, Kixx will always use Atomic Deployments with a Bui
 
 In addition to the read path above, the `StaticFileStore` has a single deploy-time write method, `write()`, which allows writing binary static assets (favicons, images, fonts, CSS) to a build.
 
-### Staged-build-only writes
+### Staged-build-only, write-once publishing
 
-Asset writes must target a **staged** build: the request's `Kixx-Build-Id` is required and must differ from the current (live) build. This keeps the live asset set immutable until an atomic promotion, and it means the running server never serves a written namespace's assets until a later deploy promotes that build and restarts the process — which is why the Node read-time metadata cache (each asset's sidecar read once and held for the process lifetime) stays correct alongside the write path. Hot-patching a single live asset is intentionally not supported.
+Asset writes must target a **staged** build: the request's `Kixx-Build-Id` is required, must be a real Build ID, and must differ from the current (live) build. The first sequential PUT to a `(Build ID, key)` fixes that public address. An identical retry returns the existing asset resource without rewriting it; changed bytes, byte length, or content type return `409 StaticAssetImmutableConflict` and must be published under a new Build ID. Hot-patching a live asset is intentionally not supported.
+
+The guarantee is sequential only. Clients must serialize PUTs to the same `(Build ID, key)`: two concurrent first writers can both observe an absent asset, and neither the Node filesystem adapter nor Cloudflare KV supplies an atomic create-only operation here.
 
 ### Server-computed validators
 
@@ -183,4 +185,4 @@ The store is the source of truth for cache validators. Given the buffered bytes 
 
 ### Per-asset metadata sidecars (Node.js)
 
-The Node store records each asset's validators in its own JSON sidecar under a reserved `.meta/` subtree that mirrors the asset key (`<buildId>/.meta/css/main.css.json` for asset `css/main.css`). Because every asset owns a separate file, there is no shared index to serialize: concurrent asset PUTs to the same staged build write disjoint sidecars, and two writers of the same asset write byte-identical validators (the ETag is derived from the content), so a last-writer-wins atomic rename is safe. Each sidecar is written atomically (temp file + `rename`), and the `.meta/` subtree is kept out of the servable key space so sidecars are never served as assets.
+The Node store records each asset's validators in its own JSON sidecar under a reserved `.meta/` subtree that mirrors the asset key (`<buildId>/.meta/css/main.css.json` for asset `css/main.css`). Because every asset owns a separate file, there is no shared index to serialize for different keys. Each sidecar is written atomically (temp file + `rename`), and the `.meta/` subtree is kept out of the servable key space so sidecars are never served as assets.

--- a/src/kixx/static-file-server/README.md
+++ b/src/kixx/static-file-server/README.md
@@ -101,6 +101,49 @@ export default [
 ];
 ```
 
+## Serving Immutable Build Assets
+
+Use `StaticAssetRequestHandler` for assets whose URL carries the Build ID: `/assets/:build_id/*pathname`. Unlike `StaticFileRequestHandler`, it takes both the namespace and key from the route params. A file stored under an older Build ID remains reachable at its original URL until that namespace is pruned, which lets cached HTML continue to load the exact assets it named after a deployment.
+
+```js
+import { StaticAssetRequestHandler } from './kixx/static-file-server/static-file-server-request-handlers.js';
+
+{
+    pattern: '/assets/:build_id/*pathname',
+    name: 'build-assets',
+    targets: [
+        {
+            name: 'serve-asset',
+            methods: [ 'GET', 'HEAD' ],
+            requestHandlers: [ StaticAssetRequestHandler() ],
+        },
+    ],
+}
+```
+
+`buildIdParam` and `pathnameParam` default to `build_id` and `pathname`, so the route above needs no handler options. When a route uses different parameter names, pass them explicitly to keep the handler aligned with that route:
+
+```js
+{
+    pattern: '/releases/:release/*file',
+    name: 'release-assets',
+    targets: [
+        {
+            name: 'serve-asset',
+            methods: [ 'GET', 'HEAD' ],
+            requestHandlers: [
+                StaticAssetRequestHandler({
+                    buildIdParam: 'release',
+                    pathnameParam: 'file',
+                }),
+            ],
+        },
+    ],
+}
+```
+
+This handler uses `public, max-age=31536000, immutable` by default while still supplying ETag and Last-Modified validators for force reloads. It validates the Build ID and wildcard path before reading the store: malformed input is a 400, and a well-formed asset absent from the named namespace is a 404. Asset upload keys must omit the URL prefix and Build ID — for example, publishing `stylesheets/stylesheet.css` produces the URL `/assets/<build-id>/stylesheets/stylesheet.css`.
+
 ## How Static File Serving Works
 
 The `StaticFileRequestHandler` delegates to an internal Kixx component called the `StaticFileStore` which stores files by key. The `StaticFileRequestHandler` uses the request pathname, excluding query parameters and hashes, as the file key along with the current Build ID as the namespace to support Atomic Deployments. The `StaticFileStore` then looks up the file by key and namespace and returns a result.

--- a/src/kixx/static-file-server/static-file-etag.js
+++ b/src/kixx/static-file-server/static-file-etag.js
@@ -1,0 +1,11 @@
+import { sha256Hex } from '../utils/crypto.js';
+
+
+/**
+ * Computes the quoted strong SHA-256 ETag used for static-file bytes.
+ * @param {ArrayBuffer|ArrayBufferView|string} body - Bytes or text to hash.
+ * @returns {Promise<string>} Quoted lowercase SHA-256 ETag.
+ */
+export async function computeStaticFileEtag(body) {
+    return `"${ await sha256Hex(body) }"`;
+}

--- a/src/kixx/static-file-server/static-file-server-request-handlers.js
+++ b/src/kixx/static-file-server/static-file-server-request-handlers.js
@@ -2,7 +2,7 @@ import { isNonEmptyString } from '../assertions/mod.js';
 import { BadRequestError, NotFoundError } from '../errors/mod.js';
 
 import validatePathname from '../utils/validate-pathname.js';
-import { NO_BUILD_ID_SEGMENT } from '../utils/build-id.js';
+import { NO_BUILD_ID_SEGMENT, validateBuildId } from '../utils/build-id.js';
 
 
 /**
@@ -183,7 +183,9 @@ function resolveAssetLocation(request, options) {
     if (!isNonEmptyString(buildId)) {
         throw new BadRequestError(`Missing Build ID pathname param: ${ buildIdParam }`);
     }
-    validatePathname(buildId);
+    const namespace = buildId === NO_BUILD_ID_SEGMENT
+        ? null
+        : validateBuildId(buildId);
 
     if (!Array.isArray(pathname) || pathname.length === 0) {
         throw new BadRequestError(`Missing asset pathname param: ${ pathnameParam }`);
@@ -197,7 +199,7 @@ function resolveAssetLocation(request, options) {
 
     return {
         key,
-        namespace: buildId === NO_BUILD_ID_SEGMENT ? null : buildId,
+        namespace,
     };
 }
 

--- a/src/kixx/static-file-server/static-file-server-request-handlers.js
+++ b/src/kixx/static-file-server/static-file-server-request-handlers.js
@@ -1,7 +1,8 @@
 import { isNonEmptyString } from '../assertions/mod.js';
-import { NotFoundError } from '../errors/mod.js';
+import { BadRequestError, NotFoundError } from '../errors/mod.js';
 
 import validatePathname from '../utils/validate-pathname.js';
+import { NO_BUILD_ID_SEGMENT } from '../utils/build-id.js';
 
 
 /**
@@ -21,6 +22,7 @@ import validatePathname from '../utils/validate-pathname.js';
 // (via ETag/If-None-Match) before reusing the asset. Callers override per route
 // for long-lived, fingerprinted assets.
 const DEFAULT_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
 
 
 /**
@@ -93,36 +95,63 @@ export function StaticFileRequestHandler(options) {
             skip();
         }
 
-        const contentType = isNonEmptyString(contentTypeOverride)
-            ? contentTypeOverride
-            : result.contentType;
+        return respondWithStaticFile(request, response, result, {
+            cacheControl,
+            contentTypeOverride,
+        });
+    };
+}
 
-        // Cache-Control and the validators apply to both the 200 and the 304 below.
-        response.setHeader('cache-control', cacheControl);
-        if (result.etag) {
-            response.setHeader('etag', result.etag);
-        }
-        if (result.lastModified) {
-            response.setHeader('last-modified', result.lastModified.toUTCString());
+/**
+ * Creates a request handler for immutable Build-ID-namespaced static assets.
+ *
+ * The handler reads both the namespace and file key from route pathname params,
+ * so an asset URL can reach any Build ID that remains in the store rather than
+ * only the runtime's current build. Its default cache policy permits browsers
+ * and CDNs to keep a build asset for one year without revalidation.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.contentType] - Force the `Content-Type` header instead
+ *   of using the store's value.
+ * @param {string} [options.cacheControl] - Force the `Cache-Control` header.
+ *   Defaults to `public, max-age=31536000, immutable`.
+ * @param {boolean} [options.computeEtag=true] - When the store has no precomputed
+ *   ETag, compute one. Set `false` to skip ETag work.
+ * @param {string} [options.buildIdParam='build_id'] - Name of the pathname param
+ *   carrying the Build ID namespace.
+ * @param {string} [options.pathnameParam='pathname'] - Name of the wildcard
+ *   pathname param carrying the file key segments.
+ * @returns {function(RequestContext, ServerRequestInterface, ServerResponse): Promise<ServerResponse>}
+ *   Async request handler for a dedicated static-asset route.
+ * @throws {BadRequestError} When a required pathname param is absent or unsafe.
+ * @throws {NotFoundError} When the requested asset is absent from the store.
+ */
+export function StaticAssetRequestHandler(options) {
+    options = options ?? {};
+
+    const {
+        contentType: contentTypeOverride,
+        cacheControl = IMMUTABLE_CACHE_CONTROL,
+        computeEtag = true,
+        buildIdParam = 'build_id',
+        pathnameParam = 'pathname',
+    } = options;
+
+    return async function staticAssetRequestHandler(context, request, response) {
+        const { namespace, key } = resolveAssetLocation(request, {
+            buildIdParam,
+            pathnameParam,
+        });
+        const store = context.getService('StaticFileStore');
+        const result = await store.read(context, { key, namespace, computeEtag });
+
+        if (!result) {
+            throw new NotFoundError(`Static asset not found: ${ request.url.pathname }`);
         }
 
-        if (isNotModified(request, result)) {
-            await cancelBody(result.body);
-            // 304 carries validators but no body or body-describing headers.
-            return response.respondWithStream(304, null);
-        }
-
-        // A HEAD response carries the same headers (including Content-Length) as the
-        // GET, but no body. Cancel the file body so the opened stream/binding does
-        // not leak, then respond with headers only.
-        if (request.isHeadRequest()) {
-            await cancelBody(result.body);
-            return response.respondWithStream(200, null, { contentType, contentLength: result.contentLength });
-        }
-
-        return response.respondWithStream(200, result.body, {
-            contentType,
-            contentLength: result.contentLength,
+        return respondWithStaticFile(request, response, result, {
+            cacheControl,
+            contentTypeOverride,
         });
     };
 }
@@ -143,6 +172,68 @@ function handleMiss(throwNotFound, request, response) {
     }
     // Defer to the next request handler in the target chain.
     return response;
+}
+
+function resolveAssetLocation(request, options) {
+    const { buildIdParam, pathnameParam } = options;
+    const pathnameParams = request.pathnameParams;
+    const buildId = pathnameParams?.[buildIdParam];
+    const pathname = pathnameParams?.[pathnameParam];
+
+    if (!isNonEmptyString(buildId)) {
+        throw new BadRequestError(`Missing Build ID pathname param: ${ buildIdParam }`);
+    }
+    validatePathname(buildId);
+
+    if (!Array.isArray(pathname) || pathname.length === 0) {
+        throw new BadRequestError(`Missing asset pathname param: ${ pathnameParam }`);
+    }
+
+    const key = pathname.join('/');
+    if (!isNonEmptyString(key)) {
+        throw new BadRequestError(`Missing asset pathname param: ${ pathnameParam }`);
+    }
+    validatePathname(key);
+
+    return {
+        key,
+        namespace: buildId === NO_BUILD_ID_SEGMENT ? null : buildId,
+    };
+}
+
+async function respondWithStaticFile(request, response, result, options) {
+    const { cacheControl, contentTypeOverride } = options;
+    const contentType = isNonEmptyString(contentTypeOverride)
+        ? contentTypeOverride
+        : result.contentType;
+
+    // Cache-Control and the validators apply to both the 200 and the 304 below.
+    response.setHeader('cache-control', cacheControl);
+    if (result.etag) {
+        response.setHeader('etag', result.etag);
+    }
+    if (result.lastModified) {
+        response.setHeader('last-modified', result.lastModified.toUTCString());
+    }
+
+    if (isNotModified(request, result)) {
+        await cancelBody(result.body);
+        // 304 carries validators but no body or body-describing headers.
+        return response.respondWithStream(304, null);
+    }
+
+    // A HEAD response carries the same headers (including Content-Length) as the
+    // GET, but no body. Cancel the file body so the opened stream/binding does
+    // not leak, then respond with headers only.
+    if (request.isHeadRequest()) {
+        await cancelBody(result.body);
+        return response.respondWithStream(200, null, { contentType, contentLength: result.contentLength });
+    }
+
+    return response.respondWithStream(200, result.body, {
+        contentType,
+        contentLength: result.contentLength,
+    });
 }
 
 function isNotModified(request, result) {

--- a/src/kixx/static-file-server/static-file-server-store-interface.js
+++ b/src/kixx/static-file-server/static-file-server-store-interface.js
@@ -10,15 +10,15 @@
  * resolves to data or to `null` when the file is absent.
  *
  * ## Keyed, namespaced lookup
- * Files are addressed by a `key` within a `namespace`. The request handler derives
- * the `key` from the request URL pathname (query string and hash excluded) and the
- * `namespace` from the deployment Build ID (`context.runtime.build?.id`). The
- * namespace is what makes Atomic Deployments possible: each build's files live
- * under their own Build ID, so a new deployment swaps the whole asset set at once
- * without overwriting the previous build's files in place. When no Build ID is
- * present (for example, a Node.js deployment that copies files out-of-band with
- * rsync or git), `namespace` is `null` and the store reads from its un-namespaced
- * root.
+ * Files are addressed by a `key` within a `namespace`. `StaticFileRequestHandler`
+ * derives both from the request URL and current runtime Build ID
+ * (`context.runtime.build?.id`), while `StaticAssetRequestHandler` takes both from
+ * its Build-ID-addressed asset route. The namespace is what makes Atomic
+ * Deployments possible: each build's files live under their own Build ID, so a new
+ * deployment swaps the whole asset set at once without overwriting the previous
+ * build's files in place. When no Build ID is present (for example, a Node.js
+ * deployment that copies files out-of-band with rsync or git), `namespace` is
+ * `null` and the store reads from its un-namespaced root.
  *
  * ## Return value: a parts object, not a Web `Response`
  * `read()` resolves to a {@link StaticFileResult} — the file body stream plus the
@@ -58,7 +58,8 @@
  * API to upload a build's static assets to a staged (non-current) Build ID
  * namespace — the static-asset analogue of how the Hyperview service accepts
  * template/page/include writes. Static files are still primarily published by the
- * out-of-band Kixx build tooling; `write()` is the in-application alternative.
+ * out-of-band Kixx build tooling; `write()` is the in-application alternative and
+ * remains overwrite-capable for those callers.
  *
  * `write()` is the store's source of truth for cache validators: given the
  * already-buffered bytes plus an optional content type, the store computes a strong
@@ -69,9 +70,12 @@
  * (Cloudflare: KV metadata; Node.js: a per-asset metadata sidecar), and returns the
  * written parts so the caller can echo them back to the publishing client.
  *
- * Enforcing that `namespace` is a staged, non-current Build ID is the *caller's*
- * concern (the transaction script), not the store's: the store writes wherever it
- * is told. The size cap that keeps a value within the platform's limits
+ * Enforcing that `namespace` is a staged, non-current Build ID and that a
+ * Publishing API address is sequentially write-once is the *caller's* concern
+ * (the transaction script), not the store's: the store writes wherever it is told.
+ * The Publishing API reads first and requires clients to serialize concurrent
+ * writes to one address; this port has no atomic create-only operation. The size
+ * cap that keeps a value within the platform's limits
  * (Cloudflare KV's 25 MiB) is likewise enforced upstream, before the body is
  * buffered and handed to `write()`.
  *
@@ -162,5 +166,6 @@
  *   metadata sidecar), and resolves to a {@link StaticFileWriteResult}. The
  *   `key` MUST be path-safety validated by the caller; adapters MUST independently
  *   refuse to write outside their namespace root, throwing rather than writing.
- *   Enforcing a staged, non-current `namespace` is the caller's concern.
+ *   Enforcing a staged, non-current `namespace` and sequential write-once
+ *   publishing is the caller's concern; this low-level method may overwrite.
  */

--- a/src/kixx/utils/build-id.js
+++ b/src/kixx/utils/build-id.js
@@ -1,4 +1,44 @@
+import { isNonEmptyString } from '../assertions/mod.js';
+import { BadRequestError } from '../errors/mod.js';
+
+import { isValidPathname } from './validate-pathname.js';
+
+
 // This URL-safe segment represents the flat static-file-store root when a
 // deployment has no Build ID. Hyperview writes it into asset URLs and the
 // static asset handler maps it back to a null namespace.
 export const NO_BUILD_ID_SEGMENT = 'dev';
+
+/**
+ * Reports whether a value is a real Build ID that can occupy one URL segment.
+ * @param {*} value - Candidate Build ID.
+ * @returns {boolean} True for a non-empty, safe, non-reserved Build ID.
+ */
+export function isValidBuildId(value) {
+    return isNonEmptyString(value)
+        && !value.includes('/')
+        && value !== NO_BUILD_ID_SEGMENT
+        && isValidPathname(value);
+}
+
+/**
+ * Validates an externally supplied real Build ID without changing its case.
+ * @param {*} value - Candidate Build ID.
+ * @returns {string} The validated Build ID.
+ * @throws {BadRequestError} When value is reserved or is not a safe Build ID.
+ */
+export function validateBuildId(value) {
+    if (value === NO_BUILD_ID_SEGMENT) {
+        throw new BadRequestError('The Build ID "dev" is reserved for no-build asset URLs.', {
+            code: 'ReservedBuildId',
+        });
+    }
+
+    if (!isValidBuildId(value)) {
+        throw new BadRequestError('Build ID must be one safe, non-empty URL path segment.', {
+            code: 'InvalidBuildId',
+        });
+    }
+
+    return value;
+}

--- a/src/kixx/utils/build-id.js
+++ b/src/kixx/utils/build-id.js
@@ -1,0 +1,4 @@
+// This URL-safe segment represents the flat static-file-store root when a
+// deployment has no Build ID. Hyperview writes it into asset URLs and the
+// static asset handler maps it back to a null namespace.
+export const NO_BUILD_ID_SEGMENT = 'dev';

--- a/src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js
+++ b/src/plugins/cloudflare-static-file-server/lib/static-file-server-store.js
@@ -1,5 +1,5 @@
 import { getContentType } from '../../../kixx/static-file-server/mime-types.js';
-import { sha256Hex } from '../../../kixx/utils/crypto.js';
+import { computeStaticFileEtag } from '../../../kixx/static-file-server/static-file-etag.js';
 import { assert, assertNonEmptyString, isNonEmptyString, isNumberNotNaN, isValidDate } from '../../../kixx/assertions/mod.js';
 
 /**
@@ -121,7 +121,7 @@ export default class StaticFileStore {
         // The store owns the validators: a strong (quoted) SHA-256 ETag that always
         // matches the stored bytes — byte-identical to what read() returns — plus
         // the exact length and the resolved content type (extension fallback).
-        const etag = `"${ await sha256Hex(body) }"`;
+        const etag = await computeStaticFileEtag(body);
         const contentLength = body.byteLength;
         const resolvedContentType = isNonEmptyString(contentType) ? contentType : getContentType(key);
         const lastModified = new Date();

--- a/src/plugins/node-static-file-server/lib/static-file-server-store.js
+++ b/src/plugins/node-static-file-server/lib/static-file-server-store.js
@@ -4,7 +4,7 @@ import fsp from 'node:fs/promises';
 import { Readable } from 'node:stream';
 
 import { getContentType } from '../../../kixx/static-file-server/mime-types.js';
-import { sha256Hex } from '../../../kixx/utils/crypto.js';
+import { computeStaticFileEtag } from '../../../kixx/static-file-server/static-file-etag.js';
 import {
     AssertionError,
     assert,
@@ -214,7 +214,7 @@ export default class StaticFileStore {
         // The store owns the validators: a strong (quoted) SHA-256 ETag that always
         // matches the stored bytes — byte-identical to what read() returns — plus
         // the exact length and the resolved content type (extension fallback).
-        const etag = `"${ await sha256Hex(bytes) }"`;
+        const etag = await computeStaticFileEtag(bytes);
         const contentLength = bytes.byteLength;
         const resolvedContentType = isNonEmptyString(contentType) ? contentType : getContentType(key);
         const lastModified = new Date();
@@ -284,7 +284,7 @@ export default class StaticFileStore {
         // No cached hash: read the bytes once, hash them, and serve those same
         // bytes as the body so the file is not read twice on a cache miss.
         const bytes = await fsp.readFile(resolvedPath);
-        const etag = `"${ await sha256Hex(bytes) }"`;
+        const etag = await computeStaticFileEtag(bytes);
         this.#etagCache.set(cacheKey, etag);
 
         return { etag, body: streamFromBytes(bytes) };

--- a/src/templates/base/admin-login.html
+++ b/src/templates/base/admin-login.html
@@ -4,13 +4,9 @@
         {{>common-site-meta.html}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <link href="/assets/stylesheets/{{ build_id }}/admin.css" rel="stylesheet">
-        {{ else }}
-        <link href="/stylesheets/admin.css" rel="stylesheet">
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <link href="/assets/{{ build_id }}/stylesheets/admin.css" rel="stylesheet">
 
         {{#if includes.page_stylesheet }}
         <style>{{{ includes.page_stylesheet }}}</style>
@@ -32,12 +28,8 @@
         {{/if}}{{/if}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <script type="module" src="/assets/javascript/{{ build_id }}/site.js"></script>
-        {{ else }}
-        <script type="module" src="/javascript/site.js"></script>
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <script type="module" src="/assets/{{ build_id }}/javascript/site.js"></script>
     </body>
 </html>

--- a/src/templates/base/admin.html
+++ b/src/templates/base/admin.html
@@ -4,13 +4,9 @@
         {{>common-site-meta.html}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <link href="/assets/stylesheets/{{ build_id }}/admin.css" rel="stylesheet">
-        {{ else }}
-        <link href="/stylesheets/admin.css" rel="stylesheet">
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <link href="/assets/{{ build_id }}/stylesheets/admin.css" rel="stylesheet">
 
         {{#if includes.page_stylesheet }}
         <style>{{{ includes.page_stylesheet }}}</style>
@@ -32,12 +28,8 @@
         {{/if}}{{/if}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <script type="module" src="/assets/javascript/{{ build_id }}/site.js"></script>
-        {{ else }}
-        <script type="module" src="/javascript/site.js"></script>
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <script type="module" src="/assets/{{ build_id }}/javascript/site.js"></script>
     </body>
 </html>

--- a/src/templates/base/default.html
+++ b/src/templates/base/default.html
@@ -5,13 +5,9 @@
         {{>common-seo-meta.html}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <link href="/assets/stylesheets/{{ build_id }}/stylesheet.css" rel="stylesheet">
-        {{ else }}
-        <link href="/stylesheets/stylesheet.css" rel="stylesheet">
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <link href="/assets/{{ build_id }}/stylesheets/stylesheet.css" rel="stylesheet">
 
         {{#if includes.page_stylesheet }}
         <style>{{{ includes.page_stylesheet }}}</style>
@@ -31,12 +27,8 @@
         {{/if}}{{/if}}
 
         {{!--
-            In remote environments we use the static asset path and the build_id
-            namespace to enable long lived caching of static assets. --}}
-        {{#if build_id}}
-        <script type="module" src="/assets/javascript/{{ build_id }}/site.js"></script>
-        {{ else }}
-        <script type="module" src="/javascript/site.js"></script>
-        {{/if}}
+            The Build ID namespaces this asset URL, so it can use an immutable
+            cache policy without changing the asset named by this page. --}}
+        <script type="module" src="/assets/{{ build_id }}/javascript/site.js"></script>
     </body>
 </html>

--- a/src/virtual-hosts.js
+++ b/src/virtual-hosts.js
@@ -1,5 +1,8 @@
 import { HyperviewStaticPageHandler, HyperviewDynamicPageHandler } from './kixx/hyperview/hyperview-request-handlers.js';
-import { StaticFileRequestHandler } from './kixx/static-file-server/static-file-server-request-handlers.js';
+import {
+    StaticAssetRequestHandler,
+    StaticFileRequestHandler,
+} from './kixx/static-file-server/static-file-server-request-handlers.js';
 import adminErrorHandler from './app/presentation/error-handlers/admin-error-handler.js';
 import adminAuthErrorHandler from './app/presentation/error-handlers/admin-auth-error-handler.js';
 import jsonApiErrorHandler from './app/presentation/error-handlers/json-api-error-handler.js';
@@ -95,6 +98,19 @@ export default [
                     jsonApiErrorHandler,
                 ],
                 routes: publishingApiRoutes,
+            },
+            {
+                pattern: '/assets/:build_id/*pathname',
+                name: 'build-assets',
+                targets: [
+                    {
+                        name: 'serve-asset',
+                        methods: [ 'GET', 'HEAD' ],
+                        requestHandlers: [
+                            StaticAssetRequestHandler(),
+                        ],
+                    },
+                ],
             },
             {
                 pattern: '*',

--- a/test/end-to-end/020-publishing-api/put-static-asset-errors.test.js
+++ b/test/end-to-end/020-publishing-api/put-static-asset-errors.test.js
@@ -212,6 +212,50 @@ describe('PUT /publishing-api/v1/assets/*filepath without a build id header', ({
     });
 });
 
+describe('PUT /publishing-api/v1/assets/*filepath with a reserved build id', ({ before, it }) => {
+
+    let result;
+
+    before(async () => {
+        result = await putStaticAsset({ buildId: 'dev' });
+    });
+
+    it('responds with an HTTP 400 status code', () => {
+        assertEqual(400, result.response.status);
+    });
+
+    it('returns the reserved Build ID JSON:API error', () => {
+        assertSingleJsonApiError(result, {
+            status: '400',
+            code: 'ReservedBuildId',
+            title: 'BadRequestError',
+            detail: 'The Build ID "dev" is reserved for no-build asset URLs.',
+        });
+    });
+});
+
+describe('PUT /publishing-api/v1/assets/*filepath with a malformed build id', ({ before, it }) => {
+
+    let result;
+
+    before(async () => {
+        result = await putStaticAsset({ buildId: 'build/child' });
+    });
+
+    it('responds with an HTTP 400 status code', () => {
+        assertEqual(400, result.response.status);
+    });
+
+    it('returns the malformed Build ID JSON:API error', () => {
+        assertSingleJsonApiError(result, {
+            status: '400',
+            code: 'InvalidBuildId',
+            title: 'BadRequestError',
+            detail: 'Build ID must be one safe, non-empty URL path segment.',
+        });
+    });
+});
+
 describe('PUT /publishing-api/v1/assets/*filepath with an empty request body', ({ before, it }) => {
 
     let result;

--- a/test/end-to-end/020-publishing-api/put-static-asset.test.js
+++ b/test/end-to-end/020-publishing-api/put-static-asset.test.js
@@ -35,10 +35,10 @@ const ASSET_FILEPATH = 'e2e/nested/static-asset.png';
 const DECLARED_TYPE_ASSET_FILEPATH = 'e2e/nested/declared-type.css';
 const PARAMETERIZED_TYPE_ASSET_FILEPATH = 'e2e/nested/parameterized-type.css';
 
-// A single-segment filepath, the shape a root-served asset such as a favicon
-// takes. Carried by the republish block so it is covered without a block of
-// its own.
-const REPUBLISH_ASSET_FILEPATH = 'e2e-republish-target.css';
+// Single-segment filepaths cover the shape a root-served asset such as a favicon
+// takes. Each retry scenario owns an address so the blocks stay independent.
+const IDEMPOTENT_ASSET_FILEPATH = 'e2e-identical-retry.css';
+const IMMUTABLE_CONFLICT_ASSET_FILEPATH = 'e2e-immutable-conflict.css';
 
 // Mixed case in every directory segment, the filename, and the extension, so a
 // fold applied to any part of the filepath still fails.
@@ -110,11 +110,6 @@ describe('PUT /publishing-api/v1/assets/*filepath with happy path', ({ before, i
 
         result = await putStaticAsset(url, bytes, 'image/png');
     });
-
-    // The write cannot be read back. Asset writes are staged-only — putStaticAsset()
-    // refuses the current build with a 409 — so by construction the bytes always land
-    // in a namespace the running site is not serving. These tests pin the response
-    // contract only.
 
     it('responds with an HTTP 200 status code', () => {
         assert(result.response);
@@ -242,7 +237,7 @@ describe('PUT /publishing-api/v1/assets/*filepath with a mixed case filepath', (
     });
 
     // Assets are the one publishing resource whose filepath is case-preserving,
-    // and the reason is the read path: StaticFileRequestHandler looks the URL
+    // and the reason is the read path: StaticAssetRequestHandler looks the URL
     // pathname up in the store verbatim, so an asset published under a folded key
     // is unreachable at the URL that names it. Hyperview template, page, and
     // include addresses are canonicalized instead, so this assertion keeps that
@@ -254,28 +249,21 @@ describe('PUT /publishing-api/v1/assets/*filepath with a mixed case filepath', (
     });
 });
 
-describe('PUT /publishing-api/v1/assets/*filepath twice with different bytes', ({ before, it }) => {
+describe('PUT /publishing-api/v1/assets/*filepath with an identical retry', ({ before, it }) => {
 
     let url;
-    let secondBytes;
     let firstResult;
     let secondResult;
 
     before(async () => {
         // Construct the URL here so the test fails if it is invalid
         // instead of crashing the whole test run.
-        url = new URL(`${ getBaseUrl() }/publishing-api/v1/assets/${ REPUBLISH_ASSET_FILEPATH }`);
+        url = new URL(`${ getBaseUrl() }/publishing-api/v1/assets/${ IDEMPOTENT_ASSET_FILEPATH }`);
 
-        const firstBytes = await fsp.readFile(CSS_FIXTURE_URL);
+        const bytes = await fsp.readFile(CSS_FIXTURE_URL);
 
-        // Republish changed bytes to the same filepath and build. Re-running a
-        // publish must be safe, so the store overwrites rather than conflicting.
-        secondBytes = new TextEncoder().encode(
-            `${ new TextDecoder().decode(firstBytes) }.e2e-republished { color: #c0ffee; }\n`,
-        );
-
-        firstResult = await putStaticAsset(url, firstBytes, 'text/css');
-        secondResult = await putStaticAsset(url, secondBytes, 'text/css');
+        firstResult = await putStaticAsset(url, bytes, 'text/css');
+        secondResult = await putStaticAsset(url, bytes, 'text/css');
     });
 
     it('responds with an HTTP 200 status code both times', () => {
@@ -285,30 +273,51 @@ describe('PUT /publishing-api/v1/assets/*filepath twice with different bytes', (
         assertEqual(200, secondResult.response.status);
     });
 
-    // This block also carries the single-segment filepath, the shape a root-served
-    // asset such as a favicon takes. The wildcard has to match one segment as
-    // readily as the three the happy path sends.
-    it('returns the same filepath and build for both writes', () => {
-        assertEqual(REPUBLISH_ASSET_FILEPATH, firstResult.body.data.attributes.filepath);
-        assertEqual(REPUBLISH_ASSET_FILEPATH, secondResult.body.data.attributes.filepath);
-        assertEqual(REPUBLISH_ASSET_FILEPATH, secondResult.body.data.id);
+    it('returns the existing resource parts for both writes', () => {
+        assertEqual(IDEMPOTENT_ASSET_FILEPATH, firstResult.body.data.attributes.filepath);
+        assertEqual(IDEMPOTENT_ASSET_FILEPATH, secondResult.body.data.attributes.filepath);
+        assertEqual(IDEMPOTENT_ASSET_FILEPATH, secondResult.body.data.id);
         assertEqual(TEST_BUILD_ID, secondResult.body.data.attributes.buildId);
+        assertEqual(firstResult.body.data.attributes, secondResult.body.data.attributes);
+    });
+});
+
+describe('PUT /publishing-api/v1/assets/*filepath with conflicting bytes', ({ before, it }) => {
+
+    let assetUrl;
+    let firstBytes;
+    let firstResult;
+    let secondResult;
+    let assetResponse;
+
+    before(async () => {
+        const url = new URL(`${ getBaseUrl() }/publishing-api/v1/assets/${ IMMUTABLE_CONFLICT_ASSET_FILEPATH }`);
+        firstBytes = await fsp.readFile(CSS_FIXTURE_URL);
+        const secondBytes = new TextEncoder().encode(
+            `${ new TextDecoder().decode(firstBytes) }.e2e-republished { color: #c0ffee; }\n`,
+        );
+
+        firstResult = await putStaticAsset(url, firstBytes, 'text/css');
+        secondResult = await putStaticAsset(url, secondBytes, 'text/css');
+        assetUrl = new URL(`${ getBaseUrl() }/assets/${ TEST_BUILD_ID }/${ IMMUTABLE_CONFLICT_ASSET_FILEPATH }`);
+        assetResponse = await fetch(assetUrl);
     });
 
-    // Unlike the other publishing endpoints, where republishing changed source
-    // returns an identical payload, the asset response describes the bytes. The
-    // validators must therefore track the new content: a store that cached them
-    // per key, or a handler that reported the first write's values, would serve a
-    // stale ETag and clients would keep the superseded asset until the build id
-    // changed.
-    it('returns validators for the republished bytes', async () => {
-        assertEqual(secondBytes.byteLength, secondResult.body.data.attributes.contentLength);
-        assertEqual(await computeStrongEtag(secondBytes), secondResult.body.data.attributes.etag);
+    it('returns an immutable conflict for the second write', () => {
+        assertEqual(200, firstResult.response.status);
+        assertEqual(409, secondResult.response.status);
+        const [ error ] = secondResult.body.errors;
+        assertEqual('409', error.status);
+        assertEqual('StaticAssetImmutableConflict', error.code);
+        assertEqual('ConflictError', error.title);
+    });
 
-        assert(
-            firstResult.body.data.attributes.etag !== secondResult.body.data.attributes.etag,
-            'the republished etag must differ from the first',
-        );
+    it('continues to serve the first representation at its public asset URL', async () => {
+        assertEqual(200, assetResponse.status);
+        assertEqual('text/css', assetResponse.headers.get('content-type'));
+        assertEqual('public, max-age=31536000, immutable', assetResponse.headers.get('cache-control'));
+        assertEqual(firstResult.body.data.attributes.etag, assetResponse.headers.get('etag'));
+        assertEqual(firstBytes, new Uint8Array(await assetResponse.arrayBuffer()));
     });
 });
 

--- a/test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js
+++ b/test/unit-tests/app/presentation/request-handlers/publishing-api/put-static-asset.test.js
@@ -6,6 +6,7 @@ import {
     JSON_API_CONTENT_TYPE,
 } from '../../../../../../src/app/presentation/lib/json-api.js';
 import { putStaticAsset } from '../../../../../../src/app/presentation/request-handlers/publishing-api/put-static-asset.js';
+import { computeStaticFileEtag } from '../../../../../../src/kixx/static-file-server/static-file-etag.js';
 
 
 const CURRENT_BUILD_ID = 'build-current';
@@ -326,6 +327,28 @@ describe('putStaticAsset publishing API handler', ({ it }) => {
         assertEqual(failure, caught.cause);
         assertMatches('writing a static asset', caught.message);
     });
+
+    it('propagates an immutable asset conflict without a second write', async () => {
+        const store = makeStaticFileStore();
+        const body = bytes([ 1 ]);
+        store.readResult = {
+            body: { async cancel() {} },
+            contentType: 'image/png',
+            contentLength: 1,
+            etag: await computeStaticFileEtag(bytes([ 2 ])),
+            lastModified: null,
+        };
+        const caught = await catchAsyncError(() => putStaticAsset(
+            makeContext({ store }),
+            makeRequest({ filepath: [ 'logo.png' ], body }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ConflictError', caught.name);
+        assertEqual('StaticAssetImmutableConflict', caught.code);
+        assertEqual(0, store.writes.length);
+    });
 });
 
 function bytes(values) {
@@ -334,7 +357,13 @@ function bytes(values) {
 
 function makeStaticFileStore(onWrite) {
     const store = {
+        readResult: null,
+        reads: [],
         writes: [],
+        async read(_context, args) {
+            store.reads.push(args);
+            return store.readResult;
+        },
         async write(_context, args) {
             store.writes.push(args);
             if (onWrite) {

--- a/test/unit-tests/app/transaction-scripts/publishing/put-include.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-include.test.js
@@ -61,6 +61,24 @@ describe('putInclude Transaction Script', ({ it }) => {
         assertEqual(TARGET_BUILD_ID, result.buildId);
     });
 
+    it('rejects invalid and reserved effective Build IDs before accessing Hyperview', async () => {
+        for (const [ buildId, code ] of [ [ 'build/child', 'InvalidBuildId' ], [ 'dev', 'ReservedBuildId' ] ]) {
+            const harness = makeHarness();
+            const caught = await catchAsyncError(() => putInclude(harness.context, {
+                pathname: '/',
+                filename: 'summary.md',
+                source: 'Staged summary',
+                buildId,
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual(code, caught.code);
+            assertEqual(0, harness.calls.serviceAccess);
+            assertEqual(0, harness.calls.putIncludeContent.length);
+        }
+    });
+
     it('reports a missing effective build id before accessing Hyperview', async () => {
         const harness = makeHarness({ currentBuildId: null });
         const caught = await catchAsyncError(() => putInclude(harness.context, {

--- a/test/unit-tests/app/transaction-scripts/publishing/put-page-metadata.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-page-metadata.test.js
@@ -43,6 +43,23 @@ describe('putPageMetadata Transaction Script', ({ it }) => {
         assertEqual(TARGET_BUILD_ID, result.buildId);
     });
 
+    it('rejects invalid and reserved effective Build IDs before accessing Hyperview', async () => {
+        for (const [ buildId, code ] of [ [ 'build/child', 'InvalidBuildId' ], [ 'dev', 'ReservedBuildId' ] ]) {
+            const harness = makeHarness();
+            const caught = await catchAsyncError(() => putPageMetadata(harness.context, {
+                pathname: '/',
+                metadata: { version: 'page-v2' },
+                buildId,
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual(code, caught.code);
+            assertEqual(0, harness.calls.serviceAccess);
+            assertEqual(0, harness.calls.putPageMetadata.length);
+        }
+    });
+
     it('reports a missing effective build id before accessing Hyperview', async () => {
         const harness = makeHarness({ currentBuildId: null });
         const caught = await catchAsyncError(() => putPageMetadata(harness.context, {

--- a/test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-static-asset.test.js
@@ -2,6 +2,7 @@ import { describe } from 'kixx-test';
 import { assert, assertEqual } from 'kixx-assert';
 
 import { putStaticAsset } from '../../../../../src/app/transaction-scripts/publishing/put-static-asset.js';
+import { computeStaticFileEtag } from '../../../../../src/kixx/static-file-server/static-file-etag.js';
 
 
 const CURRENT_BUILD_ID = 'build-current';
@@ -46,6 +47,24 @@ describe('putStaticAsset Transaction Script', ({ it }) => {
         assertEqual(0, harness.calls.write.length);
     });
 
+    it('rejects invalid and reserved target Build IDs before accessing the store', async () => {
+        for (const [ buildId, code ] of [ [ 'build/child', 'InvalidBuildId' ], [ 'dev', 'ReservedBuildId' ] ]) {
+            const harness = makeHarness();
+            const caught = await catchAsyncError(() => putStaticAsset(harness.context, {
+                filepath: 'images/logo.png',
+                body: new Uint8Array([ 1 ]),
+                contentType: 'image/png',
+                buildId,
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual(code, caught.code);
+            assertEqual(0, harness.calls.serviceAccess);
+            assertEqual(0, harness.calls.write.length);
+        }
+    });
+
     it('refuses to write into the current build before accessing the store', async () => {
         const harness = makeHarness();
         const caught = await catchAsyncError(() => putStaticAsset(harness.context, {
@@ -64,6 +83,7 @@ describe('putStaticAsset Transaction Script', ({ it }) => {
             caught.message,
         );
         assertEqual(0, harness.calls.serviceAccess);
+        assertEqual(0, harness.calls.read.length);
         assertEqual(0, harness.calls.write.length);
     });
 
@@ -77,9 +97,15 @@ describe('putStaticAsset Transaction Script', ({ it }) => {
             buildId: TARGET_BUILD_ID,
         });
         const call = harness.calls.write[0];
+        const readCall = harness.calls.read[0];
 
         assertEqual(1, harness.calls.serviceAccess);
         assertEqual('StaticFileStore', harness.calls.serviceNames[0]);
+        assertEqual(1, harness.calls.read.length);
+        assertEqual(harness.context, readCall.context);
+        assertEqual('images/logo.png', readCall.options.key);
+        assertEqual(TARGET_BUILD_ID, readCall.options.namespace);
+        assertEqual(true, readCall.options.computeEtag);
         assertEqual(1, harness.calls.write.length);
         assertEqual(harness.context, call.context);
         assertEqual('images/logo.png', call.options.key);
@@ -106,6 +132,85 @@ describe('putStaticAsset Transaction Script', ({ it }) => {
         assertEqual(TARGET_BUILD_ID, result.buildId);
     });
 
+    it('returns an identical existing asset without writing and cancels its body', async () => {
+        const body = new Uint8Array([ 1, 2, 3 ]);
+        const etag = await computeStaticFileEtag(body);
+        const existing = makeExistingAsset({
+            contentType: 'image/png',
+            contentLength: body.byteLength,
+            etag,
+        });
+        const harness = makeHarness({ readResult: existing.result });
+
+        const result = await putStaticAsset(harness.context, {
+            filepath: 'images/logo.png',
+            body,
+            contentType: 'image/png',
+            buildId: TARGET_BUILD_ID,
+        });
+
+        assertEqual(1, existing.cancelCount());
+        assertEqual(0, harness.calls.write.length);
+        assertEqual('images/logo.png', result.filepath);
+        assertEqual('image/png', result.contentType);
+        assertEqual(3, result.contentLength);
+        assertEqual(etag, result.etag);
+    });
+
+    it('returns an identical existing asset with no body without writing', async () => {
+        const body = new Uint8Array([ 1, 2, 3 ]);
+        const etag = await computeStaticFileEtag(body);
+        const harness = makeHarness({
+            readResult: {
+                body: null,
+                contentType: 'image/png',
+                contentLength: body.byteLength,
+                etag,
+                lastModified: null,
+            },
+        });
+
+        const result = await putStaticAsset(harness.context, {
+            filepath: 'images/logo.png',
+            body,
+            contentType: 'image/png',
+            buildId: TARGET_BUILD_ID,
+        });
+
+        assertEqual(0, harness.calls.write.length);
+        assertEqual('images/logo.png', result.filepath);
+        assertEqual(etag, result.etag);
+    });
+
+    it('rejects changed bytes, content type, length, or missing ETag without writing', async () => {
+        const body = new Uint8Array([ 1, 2, 3 ]);
+        const etag = await computeStaticFileEtag(body);
+        const scenarios = [
+            { etag: await computeStaticFileEtag(new Uint8Array([ 3, 2, 1 ])), contentLength: 3, contentType: 'image/png' },
+            { etag, contentLength: 3, contentType: 'application/octet-stream' },
+            { etag, contentLength: 4, contentType: 'image/png' },
+            { etag: null, contentLength: 3, contentType: 'image/png' },
+        ];
+
+        for (const scenario of scenarios) {
+            const existing = makeExistingAsset(scenario);
+            const harness = makeHarness({ readResult: existing.result });
+            const caught = await catchAsyncError(() => putStaticAsset(harness.context, {
+                filepath: 'images/logo.png',
+                body,
+                contentType: 'image/png',
+                buildId: TARGET_BUILD_ID,
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('ConflictError', caught.name);
+            assertEqual('StaticAssetImmutableConflict', caught.code);
+            assertEqual(409, caught.httpStatusCode);
+            assertEqual(1, existing.cancelCount());
+            assertEqual(0, harness.calls.write.length);
+        }
+    });
+
     it('wraps store write failures as unexpected errors with their cause', async () => {
         const cause = new Error('static file store unavailable');
         const harness = makeHarness({ writeError: cause });
@@ -122,19 +227,57 @@ describe('putStaticAsset Transaction Script', ({ it }) => {
         assertEqual(cause, caught.cause);
         assertEqual(1, harness.calls.write.length);
     });
+
+    it('wraps read and body cancellation failures as unexpected errors with their cause', async () => {
+        const readCause = new Error('static file store unavailable');
+        const readHarness = makeHarness({ readError: readCause });
+        const readCaught = await catchAsyncError(() => putStaticAsset(readHarness.context, {
+            filepath: 'images/logo.png',
+            body: new Uint8Array([ 1 ]),
+            contentType: 'image/png',
+            buildId: TARGET_BUILD_ID,
+        }));
+        assertEqual('AssertionError', readCaught.name);
+        assertEqual('Unexpected error while reading an existing static asset', readCaught.message);
+        assertEqual(readCause, readCaught.cause);
+
+        const cancelCause = new Error('stream cancellation failed');
+        const existing = makeExistingAsset({ cancelError: cancelCause });
+        const cancelHarness = makeHarness({ readResult: existing.result });
+        const cancelCaught = await catchAsyncError(() => putStaticAsset(cancelHarness.context, {
+            filepath: 'images/logo.png',
+            body: new Uint8Array([ 1 ]),
+            contentType: 'image/png',
+            buildId: TARGET_BUILD_ID,
+        }));
+        assertEqual('AssertionError', cancelCaught.name);
+        assertEqual('Unexpected error while cancelling an existing static asset body', cancelCaught.message);
+        assertEqual(cancelCause, cancelCaught.cause);
+        assertEqual(0, cancelHarness.calls.write.length);
+    });
 });
 
 function makeHarness(options) {
     const {
         currentBuildId = CURRENT_BUILD_ID,
+        readResult = null,
+        readError = null,
         writeError = null,
     } = options ?? {};
     const calls = {
         serviceAccess: 0,
         serviceNames: [],
+        read: [],
         write: [],
     };
     const store = {
+        async read(context, readOptions) {
+            calls.read.push({ context, options: readOptions });
+            if (readError) {
+                throw readError;
+            }
+            return readResult;
+        },
         async write(context, writeOptions) {
             calls.write.push({ context, options: writeOptions });
             if (writeError) {
@@ -160,6 +303,36 @@ function makeHarness(options) {
     };
 
     return { context, calls };
+}
+
+function makeExistingAsset(options) {
+    const {
+        contentType = 'image/png',
+        contentLength = 1,
+        etag = '"asset-etag"',
+        cancelError = null,
+    } = options ?? {};
+    let cancelCount = 0;
+
+    return {
+        result: {
+            body: {
+                async cancel() {
+                    cancelCount += 1;
+                    if (cancelError) {
+                        throw cancelError;
+                    }
+                },
+            },
+            contentType,
+            contentLength,
+            etag,
+            lastModified: null,
+        },
+        cancelCount() {
+            return cancelCount;
+        },
+    };
 }
 
 async function catchAsyncError(fn) {

--- a/test/unit-tests/app/transaction-scripts/publishing/put-template.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-template.test.js
@@ -60,6 +60,24 @@ describe('putTemplate Transaction Script', ({ it }) => {
         assertEqual(0, getWriteCallCount(harness.calls));
     });
 
+    it('rejects invalid and reserved target Build IDs before accessing Hyperview', async () => {
+        for (const [ buildId, code ] of [ [ 'build/child', 'InvalidBuildId' ], [ 'dev', 'ReservedBuildId' ] ]) {
+            const harness = makeHarness();
+            const caught = await catchAsyncError(() => putTemplate(harness.context, {
+                kind: 'page',
+                filepath: 'home.html',
+                source: '<h1>Home</h1>',
+                buildId,
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual(code, caught.code);
+            assertEqual(0, harness.calls.serviceAccess);
+            assertEqual(0, getWriteCallCount(harness.calls));
+        }
+    });
+
     it('refuses to write into the current build before accessing Hyperview', async () => {
         const harness = makeHarness();
         const caught = await catchAsyncError(() => putTemplate(harness.context, {

--- a/test/unit-tests/kixx/context/app-runtime.test.js
+++ b/test/unit-tests/kixx/context/app-runtime.test.js
@@ -61,6 +61,14 @@ describe('AppRuntime', ({ describe }) => {
 
             assertUndefined(runtime.build);
         });
+
+        it('allows missing and null Build IDs', () => {
+            const missing = new AppRuntime({ server: {}, build: {} });
+            const nullId = new AppRuntime({ server: {}, build: { id: null } });
+
+            assertEqual(undefined, missing.build.id);
+            assertEqual(null, nullId.build.id);
+        });
     });
 
     describe('immutability', ({ it }) => {
@@ -131,6 +139,19 @@ describe('AppRuntime', ({ describe }) => {
             assert(caught, 'expected an error to be thrown');
             assertEqual('AssertionError', caught.name);
             assertMatches('server', caught.message);
+        });
+
+        it('throws an AssertionError for malformed or reserved Build IDs', () => {
+            for (const buildId of [ '', 'build/child', 'dev' ]) {
+                const caught = catchError(() => new AppRuntime({
+                    server: {},
+                    build: { id: buildId },
+                }));
+
+                assert(caught, 'expected an error to be thrown');
+                assertEqual('AssertionError', caught.name);
+                assertMatches('build id', caught.message);
+            }
         });
     });
 });

--- a/test/unit-tests/kixx/hyperview/hyperview-service.test.js
+++ b/test/unit-tests/kixx/hyperview/hyperview-service.test.js
@@ -2,6 +2,7 @@ import { describe } from 'kixx-test';
 import { assert, assertEqual, assertMatches, assertUndefined } from 'kixx-assert';
 
 import HyperviewService from '../../../../src/kixx/hyperview/hyperview-service.js';
+import { NO_BUILD_ID_SEGMENT } from '../../../../src/kixx/utils/build-id.js';
 
 
 function makeContext(buildId = 'build-1') {
@@ -10,6 +11,10 @@ function makeContext(buildId = 'build-1') {
             build: { id: buildId },
         },
     };
+}
+
+function makeContextWithoutBuild() {
+    return { runtime: {} };
 }
 
 function makeLogger() {
@@ -150,6 +155,26 @@ describe('HyperviewService', ({ describe }) => {
             const result = await service.getPageMetadata(makeContext(), '/missing');
 
             assertEqual(null, result);
+        });
+
+        it('uses the no-build placeholder in metadata when the runtime Build ID is null', async () => {
+            const stores = makeStores();
+            stores.pageDataStore.getJSONFiles = async () => [ { json: { version: 'root' } } ];
+            const service = makeService(stores);
+
+            const result = await service.getPageMetadata(makeContext(null), '/');
+
+            assertEqual(NO_BUILD_ID_SEGMENT, result.metadata.build_id);
+        });
+
+        it('uses the no-build placeholder in metadata when the runtime has no build', async () => {
+            const stores = makeStores();
+            stores.pageDataStore.getJSONFiles = async () => [ { json: { version: 'root' } } ];
+            const service = makeService(stores);
+
+            const result = await service.getPageMetadata(makeContextWithoutBuild(), '/');
+
+            assertEqual(NO_BUILD_ID_SEGMENT, result.metadata.build_id);
         });
 
         it('rejects a non-canonical pathname before reading the store', async () => {

--- a/test/unit-tests/kixx/static-file-server/static-file-etag.test.js
+++ b/test/unit-tests/kixx/static-file-server/static-file-etag.test.js
@@ -1,0 +1,13 @@
+import { describe } from 'kixx-test';
+import { assertEqual } from 'kixx-assert';
+
+import { computeStaticFileEtag } from '../../../../src/kixx/static-file-server/static-file-etag.js';
+
+
+describe('computeStaticFileEtag', ({ it }) => {
+    it('returns a quoted lowercase SHA-256 ETag', async () => {
+        const etag = await computeStaticFileEtag(new Uint8Array([ 1, 2, 3 ]));
+
+        assertEqual('"039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"', etag);
+    });
+});

--- a/test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js
+++ b/test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js
@@ -1,0 +1,399 @@
+import { describe, MockTracker } from 'kixx-test';
+import { assert, assertEqual } from 'kixx-assert';
+
+import {
+    StaticAssetRequestHandler,
+    StaticFileRequestHandler,
+} from '../../../../src/kixx/static-file-server/static-file-server-request-handlers.js';
+
+import ServerResponse from '../../../../src/kixx/http-router/server-response.js';
+import { NO_BUILD_ID_SEGMENT } from '../../../../src/kixx/utils/build-id.js';
+
+
+function makeContext(store, buildId = 'current-build') {
+    return {
+        runtime: buildId === undefined ? {} : { build: { id: buildId } },
+        getService(name) {
+            assertEqual('StaticFileStore', name);
+            return store;
+        },
+    };
+}
+
+function makeContextWithoutBuild(store) {
+    return {
+        runtime: {},
+        getService(name) {
+            assertEqual('StaticFileStore', name);
+            return store;
+        },
+    };
+}
+
+function makeStore(result) {
+    const tracker = new MockTracker();
+    const store = {
+        read: tracker.fn(() => Promise.resolve(result)),
+    };
+    return { store, tracker };
+}
+
+function makeRequest(pathname, options) {
+    const {
+        ifModifiedSince = null,
+        ifNoneMatch = null,
+        isHead = false,
+        pathnameParams = null,
+    } = options ?? {};
+
+    return {
+        ifModifiedSince,
+        ifNoneMatch,
+        pathnameParams,
+        url: { pathname },
+        isHeadRequest() {
+            return isHead;
+        },
+    };
+}
+
+function makeResponse() {
+    return new ServerResponse();
+}
+
+function makeResult(options) {
+    const tracker = new MockTracker();
+    const body = { cancel: tracker.fn(() => Promise.resolve()) };
+    const result = {
+        body,
+        contentLength: 42,
+        contentType: 'text/css',
+        etag: '"asset-etag"',
+        lastModified: new Date('2026-01-02T03:04:05.900Z'),
+        ...options,
+    };
+    return { body, result, tracker };
+}
+
+async function catchAsyncError(fn) {
+    try {
+        await fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}
+
+function assertError(error, name, code) {
+    assert(error, 'expected an error to be thrown');
+    assertEqual(name, error.name);
+    assertEqual(code, error.code);
+}
+
+
+describe('static-file-server-request-handlers', ({ describe }) => {
+    describe('StaticFileRequestHandler', ({ it }) => {
+        it('reads the leading-slash-stripped pathname in the current build namespace', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticFileRequestHandler()(makeContext(store), makeRequest('/styles/main.css'), makeResponse());
+
+            const options = store.read.mock.getCall(0).arguments[1];
+            assertEqual('styles/main.css', options.key);
+            assertEqual('current-build', options.namespace);
+        });
+
+        it('uses a null namespace when the runtime has no build', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticFileRequestHandler()(makeContextWithoutBuild(store), makeRequest('/site.css'), makeResponse());
+
+            assertEqual(null, store.read.mock.getCall(0).arguments[1].namespace);
+        });
+
+        it('forwards the computeEtag option to the store', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticFileRequestHandler({ computeEtag: false })(makeContext(store), makeRequest('/site.css'), makeResponse());
+
+            assertEqual(false, store.read.mock.getCall(0).arguments[1].computeEtag);
+        });
+
+        it('treats the root pathname as a miss without reading the store', async () => {
+            const { store } = makeStore(null);
+            const error = await catchAsyncError(() => StaticFileRequestHandler()(makeContext(store), makeRequest('/'), makeResponse()));
+
+            assertError(error, 'NotFoundError', 'NOT_FOUND_ERROR');
+            assertEqual(0, store.read.mock.callCount());
+        });
+
+        it('returns the untouched response for a root miss when configured to fall through', async () => {
+            const { store } = makeStore(null);
+            const response = makeResponse();
+
+            const result = await StaticFileRequestHandler({ throwNotFound: false })(makeContext(store), makeRequest('/'), response);
+
+            assertEqual(response, result);
+            assertEqual(0, store.read.mock.callCount());
+        });
+
+        it('throws on a store miss, or falls through when configured', async () => {
+            const first = makeStore(null);
+            const error = await catchAsyncError(() => StaticFileRequestHandler()(makeContext(first.store), makeRequest('/missing'), makeResponse()));
+            assertError(error, 'NotFoundError', 'NOT_FOUND_ERROR');
+
+            const second = makeStore(null);
+            const response = makeResponse();
+            const result = await StaticFileRequestHandler({ throwNotFound: false })(makeContext(second.store), makeRequest('/missing'), response);
+            assertEqual(response, result);
+        });
+
+        it('uses the pathname option instead of the request pathname', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticFileRequestHandler({ pathname: '/rewritten.css' })(makeContext(store), makeRequest('/original.css'), makeResponse());
+
+            assertEqual('rewritten.css', store.read.mock.getCall(0).arguments[1].key);
+        });
+
+        it('uses an explicit content type over the store value', async () => {
+            const { result } = makeResult({ contentType: 'text/plain' });
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler({ contentType: 'text/css' })(makeContext(store), makeRequest('/site.css'), makeResponse());
+
+            assertEqual('text/css', response.headers.get('content-type'));
+        });
+
+        it('uses the store content type when no override is configured', async () => {
+            const { result } = makeResult({ contentType: 'text/plain' });
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.txt'), makeResponse());
+
+            assertEqual('text/plain', response.headers.get('content-type'));
+        });
+
+        it('sets the revalidation cache policy by default and honors an override', async () => {
+            const first = makeStore(makeResult().result);
+            const defaultResponse = await StaticFileRequestHandler()(makeContext(first.store), makeRequest('/site.css'), makeResponse());
+            assertEqual('public, max-age=0, must-revalidate', defaultResponse.headers.get('cache-control'));
+
+            const second = makeStore(makeResult().result);
+            const customResponse = await StaticFileRequestHandler({ cacheControl: 'public, max-age=60' })(makeContext(second.store), makeRequest('/site.css'), makeResponse());
+            assertEqual('public, max-age=60', customResponse.headers.get('cache-control'));
+        });
+
+        it('skips later handlers only when configured after finding a file', async () => {
+            const first = makeStore(makeResult().result);
+            const skip = new MockTracker().fn();
+            await StaticFileRequestHandler({ skipWhenFound: true })(makeContext(first.store), makeRequest('/site.css'), makeResponse(), skip);
+            assertEqual(1, skip.mock.callCount());
+
+            const second = makeStore(makeResult().result);
+            const noSkip = new MockTracker().fn();
+            await StaticFileRequestHandler({ skipWhenFound: false })(makeContext(second.store), makeRequest('/site.css'), makeResponse(), noSkip);
+            assertEqual(0, noSkip.mock.callCount());
+        });
+
+        it('rejects an unsafe pathname before reading the store', async () => {
+            const { store } = makeStore(null);
+            const error = await catchAsyncError(() => StaticFileRequestHandler()(makeContext(store), makeRequest('/../secret'), makeResponse()));
+
+            assertError(error, 'BadRequestError', 'BAD_REQUEST_ERROR');
+            assertEqual(0, store.read.mock.callCount());
+        });
+
+        it('responds with the file body and response headers', async () => {
+            const { body, result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.css'), makeResponse());
+
+            assertEqual(200, response.status);
+            assertEqual(body, response.body);
+            assertEqual('text/css', response.headers.get('content-type'));
+            assertEqual('42', response.headers.get('content-length'));
+            assertEqual('"asset-etag"', response.headers.get('etag'));
+            assertEqual('Fri, 02 Jan 2026 03:04:05 GMT', response.headers.get('last-modified'));
+        });
+
+        it('returns 304 for a matching ETag and cancels the body', async () => {
+            const { body, result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.css', { ifNoneMatch: 'asset-etag' }), makeResponse());
+
+            assertEqual(304, response.status);
+            assertEqual(null, response.body);
+            assertEqual(null, response.headers.get('content-length'));
+            assertEqual('"asset-etag"', response.headers.get('etag'));
+            assertEqual(1, body.cancel.mock.callCount());
+        });
+
+        it('gives If-None-Match precedence over If-Modified-Since', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.css', {
+                ifModifiedSince: new Date('2026-01-03T00:00:00Z'),
+                ifNoneMatch: 'different-etag',
+            }), makeResponse());
+
+            assertEqual(200, response.status);
+        });
+
+        it('returns 304 when If-Modified-Since matches at HTTP date precision', async () => {
+            const { body, result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.css', {
+                ifModifiedSince: new Date('2026-01-02T03:04:05.000Z'),
+            }), makeResponse());
+
+            assertEqual(304, response.status);
+            assertEqual(1, body.cancel.mock.callCount());
+        });
+
+        it('returns headers without a body for HEAD and cancels the source stream', async () => {
+            const { body, result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticFileRequestHandler()(makeContext(store), makeRequest('/site.css', { isHead: true }), makeResponse());
+
+            assertEqual(200, response.status);
+            assertEqual(null, response.body);
+            assertEqual('42', response.headers.get('content-length'));
+            assertEqual(1, body.cancel.mock.callCount());
+        });
+    });
+
+    describe('StaticAssetRequestHandler', ({ it }) => {
+        it('reads the namespace and joined key from pathname params, ignoring the runtime build', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticAssetRequestHandler()(makeContext(store, 'current-build'), makeRequest('/assets/previous-build/styles/main.css', {
+                pathnameParams: { build_id: 'previous-build', pathname: [ 'styles', 'main.css' ] },
+            }), makeResponse());
+
+            const options = store.read.mock.getCall(0).arguments[1];
+            assertEqual('previous-build', options.namespace);
+            assertEqual('styles/main.css', options.key);
+        });
+
+        it('serves a stale Build ID and preserves case in the key', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticAssetRequestHandler()(makeContext(store, 'current-build'), makeRequest('/assets/old/CSS/Main.CSS', {
+                pathnameParams: { build_id: 'old', pathname: [ 'CSS', 'Main.CSS' ] },
+            }), makeResponse());
+
+            assertEqual(200, response.status);
+            assertEqual('old', store.read.mock.getCall(0).arguments[1].namespace);
+            assertEqual('CSS/Main.CSS', store.read.mock.getCall(0).arguments[1].key);
+        });
+
+        it('maps only the no-build placeholder to the flat-root namespace', async () => {
+            const first = makeStore(makeResult().result);
+            await StaticAssetRequestHandler()(makeContext(first.store), makeRequest('/assets/dev/site.css', {
+                pathnameParams: { build_id: NO_BUILD_ID_SEGMENT, pathname: [ 'site.css' ] },
+            }), makeResponse());
+            assertEqual(null, first.store.read.mock.getCall(0).arguments[1].namespace);
+
+            const second = makeStore(makeResult().result);
+            await StaticAssetRequestHandler()(makeContext(second.store), makeRequest('/assets/development/site.css', {
+                pathnameParams: { build_id: 'development', pathname: [ 'site.css' ] },
+            }), makeResponse());
+            assertEqual('development', second.store.read.mock.getCall(0).arguments[1].namespace);
+        });
+
+        it('rejects missing and empty Build ID params before reading the store', async () => {
+            for (const buildId of [ undefined, '' ]) {
+                const { store } = makeStore(null);
+                const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets', {
+                    pathnameParams: { build_id: buildId, pathname: [ 'site.css' ] },
+                }), makeResponse()));
+                assertError(error, 'BadRequestError', 'BAD_REQUEST_ERROR');
+                assertEqual(0, store.read.mock.callCount());
+            }
+        });
+
+        it('rejects unsafe Build ID params before reading the store', async () => {
+            for (const buildId of [ '..', '.hidden', 'bad id', 'bad@id' ]) {
+                const { store } = makeStore(null);
+                const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets', {
+                    pathnameParams: { build_id: buildId, pathname: [ 'site.css' ] },
+                }), makeResponse()));
+                assertError(error, 'BadRequestError', 'BAD_REQUEST_ERROR');
+                assertEqual(0, store.read.mock.callCount());
+            }
+        });
+
+        it('rejects missing, empty, and unsafe asset pathname params before reading the store', async () => {
+            for (const pathname of [ undefined, [], [ '' ], [ 'css', '', 'site.css' ], [ '..', 'site.css' ] ]) {
+                const { store } = makeStore(null);
+                const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets', {
+                    pathnameParams: { build_id: 'build-1', pathname },
+                }), makeResponse()));
+                assertError(error, 'BadRequestError', 'BAD_REQUEST_ERROR');
+                assertEqual(0, store.read.mock.callCount());
+            }
+        });
+
+        it('throws NotFoundError for a well-formed store miss', async () => {
+            const { store } = makeStore(null);
+            const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets/build-1/missing.css', {
+                pathnameParams: { build_id: 'build-1', pathname: [ 'missing.css' ] },
+            }), makeResponse()));
+
+            assertError(error, 'NotFoundError', 'NOT_FOUND_ERROR');
+        });
+
+        it('uses the immutable cache policy by default and honors an override', async () => {
+            const first = makeStore(makeResult().result);
+            const defaultResponse = await StaticAssetRequestHandler()(makeContext(first.store), makeRequest('/assets/build-1/site.css', {
+                pathnameParams: { build_id: 'build-1', pathname: [ 'site.css' ] },
+            }), makeResponse());
+            assertEqual('public, max-age=31536000, immutable', defaultResponse.headers.get('cache-control'));
+
+            const second = makeStore(makeResult().result);
+            const customResponse = await StaticAssetRequestHandler({ cacheControl: 'public, max-age=60' })(makeContext(second.store), makeRequest('/assets/build-1/site.css', {
+                pathnameParams: { build_id: 'build-1', pathname: [ 'site.css' ] },
+            }), makeResponse());
+            assertEqual('public, max-age=60', customResponse.headers.get('cache-control'));
+        });
+
+        it('honors custom pathname parameter names', async () => {
+            const { result } = makeResult();
+            const { store } = makeStore(result);
+
+            await StaticAssetRequestHandler({ buildIdParam: 'release', pathnameParam: 'file' })(makeContext(store), makeRequest('/assets/release/site.css', {
+                pathnameParams: { release: 'release-1', file: [ 'site.css' ] },
+            }), makeResponse());
+
+            const options = store.read.mock.getCall(0).arguments[1];
+            assertEqual('release-1', options.namespace);
+            assertEqual('site.css', options.key);
+        });
+
+        it('uses the shared conditional response mapping for matching ETags', async () => {
+            const { body, result } = makeResult();
+            const { store } = makeStore(result);
+
+            const response = await StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets/build-1/site.css', {
+                ifNoneMatch: 'asset-etag',
+                pathnameParams: { build_id: 'build-1', pathname: [ 'site.css' ] },
+            }), makeResponse());
+
+            assertEqual(304, response.status);
+            assertEqual(null, response.body);
+            assertEqual(1, body.cancel.mock.callCount());
+        });
+    });
+});

--- a/test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js
+++ b/test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js
@@ -325,14 +325,24 @@ describe('static-file-server-request-handlers', ({ describe }) => {
         });
 
         it('rejects unsafe Build ID params before reading the store', async () => {
-            for (const buildId of [ '..', '.hidden', 'bad id', 'bad@id' ]) {
+            for (const buildId of [ '..', '.hidden', 'bad id', 'bad@id', 'build/child' ]) {
                 const { store } = makeStore(null);
                 const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets', {
                     pathnameParams: { build_id: buildId, pathname: [ 'site.css' ] },
                 }), makeResponse()));
-                assertError(error, 'BadRequestError', 'BAD_REQUEST_ERROR');
+                assertError(error, 'BadRequestError', 'InvalidBuildId');
                 assertEqual(0, store.read.mock.callCount());
             }
+        });
+
+        it('rejects a decoded multi-segment Build ID before reading the store', async () => {
+            const { store } = makeStore(null);
+            const error = await catchAsyncError(() => StaticAssetRequestHandler()(makeContext(store), makeRequest('/assets', {
+                pathnameParams: { build_id: 'dev/child', pathname: [ 'site.css' ] },
+            }), makeResponse()));
+
+            assertError(error, 'BadRequestError', 'InvalidBuildId');
+            assertEqual(0, store.read.mock.callCount());
         });
 
         it('rejects missing, empty, and unsafe asset pathname params before reading the store', async () => {

--- a/test/unit-tests/kixx/utils/build-id.test.js
+++ b/test/unit-tests/kixx/utils/build-id.test.js
@@ -1,0 +1,48 @@
+import { describe } from 'kixx-test';
+import { assert, assertEqual } from 'kixx-assert';
+
+import {
+    isValidBuildId,
+    NO_BUILD_ID_SEGMENT,
+    validateBuildId,
+} from '../../../../src/kixx/utils/build-id.js';
+
+
+describe('Build ID utilities', ({ it }) => {
+    it('accepts safe case-preserving single-segment Build IDs', () => {
+        for (const buildId of [ 'Build-2026_07', 'release.1', 'a.b-c_d' ]) {
+            assertEqual(true, isValidBuildId(buildId));
+            assertEqual(buildId, validateBuildId(buildId));
+        }
+    });
+
+    it('rejects empty, non-string, and unsafe Build IDs', () => {
+        for (const buildId of [ undefined, null, '', 42, 'build/child', 'bad id', 'bad@id', '.hidden', '..' ]) {
+            assertEqual(false, isValidBuildId(buildId));
+
+            const caught = catchError(() => validateBuildId(buildId));
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual('InvalidBuildId', caught.code);
+        }
+    });
+
+    it('rejects only the exact no-build placeholder as reserved', () => {
+        assertEqual(false, isValidBuildId(NO_BUILD_ID_SEGMENT));
+
+        const caught = catchError(() => validateBuildId(NO_BUILD_ID_SEGMENT));
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual('ReservedBuildId', caught.code);
+        assertEqual(true, isValidBuildId('DEV'));
+    });
+});
+
+function catchError(fn) {
+    try {
+        fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}

--- a/tools/devserver.js
+++ b/tools/devserver.js
@@ -63,22 +63,28 @@ const devServer = http.createServer((request, response) => {
 });
 
 async function handleRequest(request, response) {
-    const pathname = new URL(request.url, 'http://localhost').pathname;
+    // Retain dot segments for the source-file handlers' validation rather than
+    // letting URL normalization collapse a traversal attempt before it reaches
+    // their shared path-safety guard.
+    const pathname = request.url.split(/[?#]/)[0];
+    const assetPathname = pathname.replace(/^\/assets\/[^/]+(?=\/)/, '');
+    const sourcePathname = assetPathname === pathname ? pathname : assetPathname;
 
     // CSS source files live in src/stylesheets/ and are not copied into the
     // app server's served public/ directory by any build step, so serve them
     // straight from source here rather than proxying to (and possibly
-    // restarting) the app server child process.
-    if (isStylesheetRequest(pathname)) {
-        await serveStylesheetFile(request, response, pathname);
+    // restarting) the app server child process. Asset URLs use the same source
+    // path after their Build ID segment has been stripped above.
+    if (isStylesheetRequest(sourcePathname)) {
+        await serveStylesheetFile(request, response, sourcePathname);
         return;
     }
 
     // Browser JavaScript modules live in src/javascript/ and, like the
     // stylesheets above, are not copied into the app server's served public/
     // directory by any build step, so serve them straight from source here.
-    if (isJavascriptRequest(pathname)) {
-        await serveJavascriptFile(request, response, pathname);
+    if (isJavascriptRequest(sourcePathname)) {
+        await serveJavascriptFile(request, response, sourcePathname);
         return;
     }
 


### PR DESCRIPTION
# Static Asset Request Handler Implementation Plan

Split static file serving into two request handlers with different lookup rules and
cache policies, and move the application's CSS and JavaScript onto Build-ID-namespaced,
long-lived-cacheable URLs.

## Implementation Approach

Today `StaticFileRequestHandler` (`src/kixx/static-file-server/static-file-server-request-handlers.js`)
serves every static file with one rule: the store key comes from the URL pathname and
the namespace always comes from `context.runtime.build?.id`. That single rule cannot
express both of the use cases the application needs:

- **Catch-all files** — `/favicon.ico`, `/robots.txt`, `/site.webmanifest`. Their URLs
  are fixed and un-namespaced, their content changes between builds, and they must be
  revalidated on every use.
- **Immutable build assets** — `/assets/<build-id>/stylesheets/stylesheet.css`. Their URLs
  carry the Build ID, their content can never change for a given URL, and they should be
  cached for a year without revalidation.

The decisive difference is **where the namespace comes from**. The catch-all handler keeps
taking it from the server (`context.runtime.build.id`), so a URL can never reach another
build's files. The new asset handler takes it from the URL, which is what lets HTML cached
by a browser or CDN keep fetching the exact assets it was rendered against after a new
build is promoted. That inversion also makes the Build ID an untrusted input, so the
asset handler must validate it with the same path-safety rule already applied to keys.

Work lands in four sequential partitions: the framework handlers (Task 1), the Build ID
placeholder that lets one URL shape work with and without a deployed build (Task 2), the
application route and template wiring (Task 3), and dev server support so local
development exercises the same URLs as production (Task 4).

### Cross-cutting decisions

These were settled with the user before planning and should not be re-litigated:

1. **URL shape:** `/assets/:build_id/*pathname`. The route pattern extracts both parts;
   the handler reads `request.pathnameParams` and never parses the raw pathname. This
   keeps the URL shape owned by the route, and the resulting key
   (`stylesheets/stylesheet.css`) is byte-identical to the key the publishing API writes
   (`PUT /publishing-api/v1/assets/stylesheets/stylesheet.css`).
2. **Stale Build IDs are served, not rejected.** A URL naming any build still present in
   the store gets a 200. A pruned or unknown build gets a 404 from the ordinary store miss.
   The handler never compares the URL's Build ID against the current one.
3. **The catch-all handler is unchanged.** It keeps using the current Build ID as the
   namespace and keeps its `public, max-age=0, must-revalidate` default, so an atomic
   deploy still swaps `/favicon.ico`.
4. **Immutable policy keeps validators.** `public, max-age=31536000, immutable`, and the
   ETag / `Last-Modified` / 304 machinery stays on so a force-reloading client still gets
   a cheap answer.
5. **Names:** `StaticFileRequestHandler` (existing export, unchanged) and
   `StaticAssetRequestHandler` (new). No breaking rename.
6. **Untrusted Build ID:** validated as a safe path segment before it reaches the store —
   400 when malformed, 404 when well-formed but absent.

### Test strategy

The user has explicitly asked for unit test coverage of this work, so writing **and running**
the tests below is in scope for the tasks that own them. Follow `test/unit-tests/README.md`
for the runner API, hook semantics, and mocking rules.

Three facts set the shape of the coverage:

- **`static-file-server-request-handlers.js` has no test file today.** Task 1 refactors the
  existing handler's internals into helpers shared with a new handler, so the regression
  coverage for `StaticFileRequestHandler` is not optional busywork — it is the only thing
  that will prove the extraction did not change the behavior of the handler already serving
  every static file in the application. Write those cases even though that handler's
  observable behavior is meant to be unchanged.
- **`src/virtual-hosts.js` and the templates are configuration and markup.** This project has
  no unit test for the application's route table, and adding one would test the router, which
  `test/unit-tests/kixx/http-router/` already covers. Task 3 relies on its manual checks.
- **`tools/` has no test harness anywhere in the suite.** Task 4 is dev-only tooling and stays
  manually verified.

The new test file is `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`,
mirroring the source tree per the guide. `test/unit-tests/kixx/hyperview/hyperview-request-handlers.test.js`
is the closest existing model for request-handler tests — reuse its approach:

- File-local `makeContext()`, `makeStore()`, `makeRequest()`, `makeResponse()`, and
  `catchAsyncError()` factories rather than shared fixtures.
- `makeResponse()` returns a real `ServerResponse` (`src/kixx/http-router/server-response.js`),
  so tests assert on `response.status`, `response.headers.get(name)`, and `response.body`
  instead of on a double's recorded calls.
- The store double's `read` is a `MockTracker` mock, so the arguments the handler passes —
  specifically `namespace` — are directly assertable. That matters more than the return value
  here: the whole design rests on which namespace each handler chooses.
- The result body double only needs a tracked `cancel()` method; the handlers never read it,
  and a real `ReadableStream` would make the 304 and HEAD cancellation cases harder to assert.
- Assert on `error.name` and `error.code`, never `instanceof` — the errors come from a
  vendored module tree.

### Known risk to keep in view

Dropping the `{{#if build_id}}` conditional from the base templates (Task 3) means every
deploy target must produce a servable `/assets/<segment>/...` URL, including a Node deploy
that never sets `BUILD_ID`. Task 2's placeholder segment plus the handler's placeholder →
flat-root mapping is what covers that case. If either half is skipped, an out-of-band
deploy with no Build ID will 404 on every stylesheet.

---

### Task 1: Two static file request handlers with distinct lookup and cache rules

**Status:** Complete
**Depends on:** None
**Documentation:** `src/kixx/static-file-server/README.md`, `src/docs/server-error-handling.md`, `src/docs/code-style-guide.md`, `src/docs/code-documentation-guide.md`, `test/unit-tests/README.md`

**Objective**

`src/kixx/static-file-server/static-file-server-request-handlers.js` exports two handler
factories. `StaticFileRequestHandler` behaves exactly as it does today. A new
`StaticAssetRequestHandler` reads the Build ID namespace and the store key from route
params instead of from the runtime, and applies an immutable cache policy. The two share
their response-mapping and conditional-request code rather than duplicating it.

**Scope**

- In: both factories, their shared internals, Build-ID-segment validation, the immutable
  cache default, unit tests for both factories, the module README, and the Static File
  Server Guide entry in `AGENTS.md`.
- Out: route registration and templates (Task 3), the Build ID placeholder constant and
  its Hyperview wiring (Task 2), dev server changes (Task 4), any change to the
  `StaticFileStore` adapters or the interface contract.

**Design and invariants**

- `StaticFileRequestHandler` keeps its current name, option surface
  (`contentType`, `cacheControl`, `computeEtag`, `throwNotFound`, `skipWhenFound`,
  `pathname`), default `Cache-Control`, and behavior. Existing callers in
  `src/virtual-hosts.js` and the README examples must not need edits.
- `StaticAssetRequestHandler(options)` accepts:
  - `contentType` — force the response `Content-Type`, as today.
  - `cacheControl` — defaults to `public, max-age=31536000, immutable`.
  - `computeEtag` — defaults to `true`.
  - `buildIdParam` — pathname param holding the Build ID segment, defaults to `'build_id'`.
  - `pathnameParam` — wildcard pathname param holding the key segments, defaults to `'pathname'`.
- `StaticAssetRequestHandler` deliberately has **no** `throwNotFound`, `skipWhenFound`, or
  `pathname` option. It is mounted on a dedicated route, so a miss is always a 404 and
  there is never a later handler to fall through to. Do not add these options
  speculatively.
- **The asset handler must never read `context.runtime.build`.** The URL is the sole
  source of the namespace. This is the property that makes previous-build assets
  reachable; a "sanity check" against the current build would silently destroy it.
- Input rules for the asset handler, in order:
  1. `request.pathnameParams[buildIdParam]` must be a non-empty string, else
     `BadRequestError`.
  2. The Build ID segment goes through `validatePathname()` (`src/kixx/utils/validate-pathname.js`),
     which rejects `..`, `//`, a leading `.`, and any character outside `[a-z0-9_.-]`.
     This is the guard that keeps an attacker-chosen namespace from escaping the store root.
  3. `request.pathnameParams[pathnameParam]` must be a non-empty array, else
     `BadRequestError`.
  4. The segments are joined with `/` and the joined key goes through `validatePathname()`.
     Joining before validating is what makes an empty segment (`/assets/b1/css//main.css`)
     a 400 — the joined string contains `//`. See the equivalent reasoning in
     `src/app/presentation/request-handlers/publishing-api/route-params.js:139-153`.
- **Case is preserved** in the key. Static asset reads resolve the stored key verbatim, so
  folding case here would look for a file no write ever created. This matches
  `getWildcardFilepath()` in the publishing API, which preserves case for exactly this reason.
- A store miss throws `NotFoundError`. Per `src/docs/server-error-handling.md`, both a
  malformed URL and an absent file are expected operational errors, not assertions.
- Extract the shared tail of the current handler — `Cache-Control` / `ETag` /
  `Last-Modified` header assignment, the `isNotModified()` 304 branch, the HEAD branch, and
  the 200 stream response — into one module-private helper both factories call. Keep
  `isNotModified`, `unquoteEtag`, `toEpochSeconds`, and `cancelBody` as the single shared
  copies they already are. Do not fork this logic; a divergence between the two handlers'
  conditional-request behavior would be a subtle cache bug.
- Both factories get full JSDoc per `src/docs/code-documentation-guide.md`. The asset
  handler's block must state that the namespace comes from the URL and that any still-stored
  build is reachable.
- The placeholder → flat-root mapping described in Task 2 is implemented **here**, in the
  asset handler, but is written against the constant Task 2 introduces. If Task 1 lands
  first, add the mapping in Task 2 rather than inventing a second constant.

**Test coverage**

New file: `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`,
with one top-level `describe` and a nested `describe` per factory.

`StaticFileRequestHandler` — regression coverage proving the refactor preserved today's behavior:

- Passes the leading-slash-stripped pathname as `key` and the current `context.runtime.build.id` as `namespace`.
- Passes `namespace: null` when the runtime has no build.
- Forwards the `computeEtag` option to the store.
- A request for `/` never calls the store and throws `NotFoundError`; with `throwNotFound: false` it returns the response untouched instead.
- A store miss throws `NotFoundError`, or returns the response when `throwNotFound: false`.
- The `pathname` option overrides the request URL when deriving the key.
- The `contentType` option wins over the store's value; the store's value is used otherwise.
- Sets `cache-control: public, max-age=0, must-revalidate` by default, and the override when given.
- Calls `skip()` when `skipWhenFound: true` and a file is found, and does not when it is `false`.
- A traversal pathname throws `BadRequestError` before the store is called.

Shared response behavior — cover under whichever factory is cheaper to set up, and add one
mirror case under the other so a future divergence in the shared helper is caught:

- A hit responds 200 with the body, `content-type`, `content-length`, `etag`, and `last-modified`.
- A matching `If-None-Match` responds 304 with validators, a null body, no `content-length`, and a cancelled body stream.
- A non-matching `If-None-Match` responds 200 even when `If-Modified-Since` would have matched (RFC 9110 §13.2.2 precedence).
- `If-Modified-Since` alone responds 304, including when the stored `lastModified` carries sub-second precision that the header cannot express.
- A HEAD request responds 200 with `content-length` set, a null body, and a cancelled body stream.

`StaticAssetRequestHandler`:

- Resolves `namespace` from `pathnameParams.build_id` and `key` from the joined wildcard segments.
- **Ignores `context.runtime.build.id` entirely** — give the context a *different* current build ID and assert the store received the URL's. This is the regression guard for the design's central decision; without it, a later "sanity check" against the current build could be added without any test failing.
- Serves a stale Build ID: a URL naming a previous build reaches the store under that namespace and responds 200.
- Preserves case in the key (`/assets/b1/CSS/Main.CSS` reads that exact key).
- Missing or empty `build_id` param throws `BadRequestError`.
- Malformed `build_id` (`..`, a leading dot, a space, an out-of-whitelist character) throws `BadRequestError` before the store is called.
- Missing or empty wildcard pathname param throws `BadRequestError`.
- An empty segment in the wildcard (joining to `//`) throws `BadRequestError`.
- A traversal segment in the wildcard throws `BadRequestError`.
- A store miss throws `NotFoundError`.
- Sets `cache-control: public, max-age=31536000, immutable` by default, and honors an override.
- Honors custom `buildIdParam` and `pathnameParam` option names.

The placeholder → `null` namespace case is listed under Task 2, which introduces the constant.

**Expected touch points**

- `src/kixx/static-file-server/static-file-server-request-handlers.js` — both factories and shared internals.
- `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js` — new test file covering both factories.
- `src/kixx/static-file-server/README.md` — document the two handlers, when to reach for each, the immutable cache policy, the URL shape, and the stale-Build-ID behavior.
- `AGENTS.md` — update the Static File Server Guide index entry so it names both handlers.

Treat this list as orientation, not permission to ignore other necessary files. Record the
actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] `StaticFileRequestHandler` is exported with unchanged behavior and options.
- [ ] `StaticAssetRequestHandler` is exported and resolves namespace and key from `request.pathnameParams` only.
- [ ] A missing or malformed Build ID segment produces a `BadRequestError` (400).
- [ ] A missing or empty wildcard pathname produces a `BadRequestError` (400).
- [ ] An empty path segment in the key produces a `BadRequestError` (400).
- [ ] A well-formed URL whose namespace or key is absent from the store produces a `NotFoundError` (404).
- [ ] A found asset responds 200 with `cache-control: public, max-age=31536000, immutable`, plus `ETag` and `Last-Modified` when the store supplies them.
- [ ] `If-None-Match` and `If-Modified-Since` still produce a 304 with validators and no body; HEAD still produces headers with no body; both still cancel the body stream.
- [ ] The 304 / HEAD / 200 response mapping exists once in the module and is shared by both factories.
- [ ] Every case listed under **Test coverage** exists and passes.
- [ ] A test asserts the asset handler reads the URL's Build ID while the context carries a different one.
- [ ] The module README and the `AGENTS.md` index entry describe both handlers.

**Validation**

- `node run-linter.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/static-file-server/` — no lint errors.
- `node run-tests.js test/unit-tests/kixx/static-file-server` — the new suite passes.
- `node run-tests.js` — the full unit suite still passes, proving the shared-helper extraction broke no other caller.
- Read-through check: confirm `context.runtime.build` appears in `StaticFileRequestHandler` only, never in `StaticAssetRequestHandler`.
- Manual verification is deferred to Task 3, where the route exists to exercise these paths.

**Progress and handoff**

- Completed: Added `StaticAssetRequestHandler`, extracted the shared static-file response mapper, and added regression coverage for both handlers. Updated the static-file-server guide and its AGENTS index entry.
- Current state: Complete.
- Remaining: Task 2 must add the shared no-build placeholder and map it to the flat-root namespace.
- Decisions and discoveries: `StaticAssetRequestHandler` reads only pathname params; `context.runtime.build` appears only in `StaticFileRequestHandler`. The placeholder-to-flat-root mapping remains intentionally deferred to Task 2 because its shared constant does not exist yet.
- Actual files changed: `src/kixx/static-file-server/static-file-server-request-handlers.js`, `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`, `src/kixx/static-file-server/README.md`, `AGENTS.md`.
- Validation run: `node run-linter.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/static-file-server/` (pass); `node run-tests.js test/unit-tests/kixx/static-file-server` (26 pass); `node run-tests.js` (1363 pass); read-through `rg` check confirms one runtime Build ID reference, in `StaticFileRequestHandler` only.
- Blockers: None.

---

### Task 2: A Build ID placeholder so one asset URL shape works with or without a build

**Status:** Complete
**Depends on:** None
**Documentation:** `src/templates/README.md`, `src/docs/code-style-guide.md`, `test/unit-tests/README.md`

**Objective**

The template context always exposes a usable `build_id` value, so base templates can emit a
single `/assets/<build_id>/...` URL shape with no conditional, and that URL still resolves
when the application is running with no `BUILD_ID` (local development and out-of-band
deploys).

**Scope**

- In: the shared placeholder constant, the `metadata.build_id` assignment in
  `HyperviewService`, the asset handler's placeholder → flat-root namespace mapping, and
  unit tests for both behaviors.
- Out: template edits (Task 3), dev server routing (Task 4), and any refactor of the
  fourteen other `context.runtime.build?.id ?? null` call sites.

**Design and invariants**

- Add `src/kixx/utils/build-id.js` exporting `NO_BUILD_ID_SEGMENT = 'dev'`. A shared module
  is the honest owner: the value is a URL-shape contract between the party that writes it
  into the template context (Hyperview) and the party that reads it back off the URL (the
  static asset handler). Neither module should own a constant the other depends on.
- Do **not** add a `getCurrentBuildId(context)` helper in this task. The codebase already
  uses the inline `context.runtime.build?.id ?? null` idiom in fourteen places; introducing
  a second idiom used by one call site makes the code less consistent, not more.
- `src/kixx/hyperview/hyperview-service.js:180` becomes
  `metadata.build_id = buildId ?? NO_BUILD_ID_SEGMENT;`.
- `StaticAssetRequestHandler` maps a Build ID segment equal to `NO_BUILD_ID_SEGMENT` to a
  `null` namespace, which the stores already serve from their flat root
  (`node-static-file-server/lib/static-file-server-store.js:97-99`). This is what keeps an
  out-of-band, no-Build-ID Node deploy working once the templates lose their conditional.
- **Consequence to record in the code:** `{{#if build_id}}` is now always truthy. Any
  template that branches on it is dead-branching and must be updated (Task 3). The
  `?.json` debug output for pages will show `"build_id": "dev"` in development rather than
  `null`.
- `'dev'` is a valid path segment under `validatePathname()`, so it survives the asset
  handler's Build ID validation unchanged.

**Test coverage**

Add to `test/unit-tests/kixx/hyperview/hyperview-service.test.js`, in the `getPageMetadata`
group. Its `makeContext(buildId = 'build-1')` factory already parameterizes the Build ID, and
the existing case asserting `result.metadata.build_id === 'build-2'` already covers the
real-build path — extend, do not rewrite:

- `metadata.build_id` is the placeholder when `context.runtime.build.id` is `null`.
- `metadata.build_id` is the placeholder when the runtime carries no `build` object at all
  (`makeContext()` needs a variant that omits it). Both shapes reach production: `BUILD_ID`
  unset yields `{ id: undefined }`, and a command runtime may have no `build` key.
- Assert against the imported constant, not the literal `'dev'`, so changing the placeholder
  is a one-line change rather than a test hunt.

Add to `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`
(created in Task 1), in the `StaticAssetRequestHandler` group:

- A URL whose Build ID segment equals the placeholder calls the store with `namespace: null`.
- A URL with any other Build ID passes that literal value through, so the mapping is narrow
  and does not accidentally swallow a real build named something similar.

No test for `src/kixx/utils/build-id.js` itself. It exports one string constant with no
behavior; a test asserting `'dev' === 'dev'` documents nothing and only pins the value in a
second place.

**Expected touch points**

- `src/kixx/utils/build-id.js` — new module holding the placeholder constant.
- `src/kixx/hyperview/hyperview-service.js` — default `metadata.build_id` to the placeholder.
- `src/kixx/static-file-server/static-file-server-request-handlers.js` — map the placeholder to a null namespace.
- `test/unit-tests/kixx/hyperview/hyperview-service.test.js` — placeholder cases for the absent-build paths.
- `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js` — placeholder namespace mapping cases.

Treat this list as orientation, not permission to ignore other necessary files. Record the
actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] `NO_BUILD_ID_SEGMENT` is exported from one module and imported by both consumers.
- [ ] With `BUILD_ID` set, `metadata.build_id` is the real Build ID.
- [ ] With `BUILD_ID` unset, `metadata.build_id` is the placeholder rather than `null`.
- [ ] `StaticAssetRequestHandler` reads the placeholder segment as a `null` namespace (flat store root) and any other segment as that literal namespace.
- [ ] An inline comment at the `metadata.build_id` assignment explains why a placeholder is used instead of `null`.
- [ ] Every case listed under **Test coverage** exists and passes, asserting against the imported constant rather than the literal.

**Validation**

- `node run-linter.js src/kixx/utils/build-id.js src/kixx/hyperview/hyperview-service.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/` — no lint errors.
- `node run-tests.js test/unit-tests/kixx/hyperview test/unit-tests/kixx/static-file-server` — both suites pass.
- `node run-tests.js` — the full unit suite still passes; the `build_id` default changes a value other Hyperview tests read.
- Manual (after Task 3): `curl -s http://localhost:2026/index.json | grep build_id` reports the placeholder in development.

**Progress and handoff**

- Completed: Added the shared `NO_BUILD_ID_SEGMENT` constant; Hyperview now emits it when a runtime has no Build ID; and the asset handler maps precisely that segment to the flat store root. Added the required tests.
- Current state: Complete.
- Remaining: Task 3 must register the route and emit the asset URL shape in base templates.
- Decisions and discoveries: The placeholder is `dev`, a valid safe pathname segment. The metadata assignment includes the required rationale comment; `build_id` is now always truthy.
- Actual files changed: `src/kixx/utils/build-id.js`, `src/kixx/hyperview/hyperview-service.js`, `src/kixx/static-file-server/static-file-server-request-handlers.js`, `test/unit-tests/kixx/hyperview/hyperview-service.test.js`, `test/unit-tests/kixx/static-file-server/static-file-server-request-handlers.test.js`.
- Validation run: `node run-linter.js src/kixx/utils/build-id.js src/kixx/hyperview/hyperview-service.js src/kixx/static-file-server/static-file-server-request-handlers.js test/unit-tests/kixx/` (pass); `node run-tests.js test/unit-tests/kixx/hyperview test/unit-tests/kixx/static-file-server` (138 pass); `node run-tests.js` (1366 pass).
- Blockers: None.

---

### Task 3: Serve and reference build assets at /assets/:build_id/*pathname

**Status:** Complete
**Depends on:** Task 1, Task 2
**Documentation:** `src/app/presentation/README.md`, `src/templates/README.md`, `src/docs/frontend-development-guide.md`

**Objective**

The application serves `/assets/<build-id>/<key>` through `StaticAssetRequestHandler`, and
every base template references its stylesheet and script through that URL shape with no
conditional fallback.

**Scope**

- In: the new route in `src/virtual-hosts.js`, and the asset URLs in the three base templates.
- Out: framework handler behavior (Task 1), the placeholder constant (Task 2), dev server
  interception (Task 4), page-local `page_stylesheet` includes (inlined, unaffected), and
  unit tests (see **Test coverage** below).

**Design and invariants**

- The route is declared **before** the `'*'` catch-all in `src/virtual-hosts.js:99`. Routes
  match in declaration order, so a later declaration would let the catch-all
  `StaticFileRequestHandler` swallow `/assets/**` and look the whole path up as a key under
  the current build — the exact double-namespacing bug this work exists to remove.
- Route shape:
  ```js
  {
      pattern: '/assets/:build_id/*pathname',
      name: 'build-assets',
      targets: [
          {
              name: 'serve-asset',
              methods: [ 'GET', 'HEAD' ],
              requestHandlers: [ StaticAssetRequestHandler() ],
          },
      ],
  },
  ```
- No `errorHandlers` on the route: a 404 for a missing asset should fall through to the
  virtual host's existing handling, the same as any other unmatched resource.
- Template edits — drop the `{{#if build_id}}` / `{{ else }}` blocks entirely and emit:
  - `src/templates/base/default.html:10-14` → `/assets/{{ build_id }}/stylesheets/stylesheet.css`
  - `src/templates/base/default.html:36-40` → `/assets/{{ build_id }}/javascript/site.js`
  - `src/templates/base/admin.html:9-13` → `/assets/{{ build_id }}/stylesheets/admin.css`
  - `src/templates/base/admin-login.html:9-13` → `/assets/{{ build_id }}/stylesheets/admin.css`
  Note the Build ID moves **before** the `stylesheets/` and `javascript/` segments; the old
  URLs put it in the middle, which no route could map back onto a stored key.
- Keep the existing explanatory template comment, updated to say that the Build ID segment
  namespaces the asset and enables the immutable cache policy.
- **Coordinated change point:** the resulting store keys are `stylesheets/stylesheet.css`,
  `stylesheets/admin.css`, and `javascript/site.js`. Deploy tooling must publish assets at
  exactly those keys via `PUT /publishing-api/v1/assets/<key>` with a staged
  `Kixx-Build-Id`. Note this in the module README if it is not already stated.

**Test coverage**

No unit tests. `src/virtual-hosts.js` is the application's route table and the base templates
are markup; the suite has no precedent for testing either, and a test asserting that a route
entry exists would restate the file rather than verify behavior. Route matching itself is
already covered by `test/unit-tests/kixx/http-router/`, and the handler this route mounts is
covered by Task 1.

The gap this leaves is real and worth naming: nothing automated proves the route is declared
*ahead* of the `'*'` catch-all, which is the one ordering mistake that would silently
reintroduce double-namespacing. The manual checks below are what catch it. If this ever needs
automating, it belongs in `test/end-to-end/` alongside the existing publishing-API suites,
which exercise a running server — not in the unit suite.

**Expected touch points**

- `src/virtual-hosts.js` — import `StaticAssetRequestHandler` and add the route above the catch-all.
- `src/templates/base/default.html` — stylesheet and script URLs.
- `src/templates/base/admin.html` — stylesheet URL.
- `src/templates/base/admin-login.html` — stylesheet URL.

Treat this list as orientation, not permission to ignore other necessary files. Record the
actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] `/assets/:build_id/*pathname` is registered ahead of the `'*'` catch-all and serves GET and HEAD.
- [ ] All three base templates emit the new URL shape with no `{{#if build_id}}` branch.
- [ ] No template still references `/stylesheets/` or `/javascript/` directly.
- [ ] `/favicon.ico` and the other root files still resolve through the catch-all handler.
- [ ] The store keys implied by the templates match what the publishing API writes.

**Validation**

- `node run-linter.js src/virtual-hosts.js` — no lint errors.
- `node run-tests.js` — the full unit suite still passes.
- Manual, with the dev server running (`node tools/devserver.js --port 2026`):
  - `curl -sI http://localhost:2026/favicon.ico` → 200 with `cache-control: public, max-age=0, must-revalidate`.
  - `curl -s http://localhost:2026/ | grep -E 'stylesheet|site.js'` → both tags carry the `/assets/dev/...` shape.
  - `curl -sI 'http://localhost:2026/assets/dev/../../etc/passwd'` → 400.
  - `curl -sI http://localhost:2026/assets/dev/stylesheets/nope.css` → 404.
- Manual, against a deployed build (cannot be run locally): request an asset under the
  previous build's ID after a promotion and confirm a 200 with the immutable
  `Cache-Control`, then confirm `If-None-Match` with the returned ETag gives a 304.

**Progress and handoff**

- Completed: Registered the build-asset GET/HEAD route before the static catch-all and migrated all base-template stylesheet and module-script URLs to `/assets/{{ build_id }}/<key>` without conditional branches.
- Current state: Complete, except for the plan's dev-server manual checks, which were not run because the repository instructions prohibit dev-server/smoke verification unless explicitly requested.
- Remaining: Task 4 must intercept these URLs in the development-server source-file handlers.
- Decisions and discoveries: Both admin templates also contained a direct script URL, so they were migrated along with the explicitly listed stylesheet URLs to satisfy the no-direct-asset-URL invariant.
- Actual files changed: `src/virtual-hosts.js`, `src/templates/base/default.html`, `src/templates/base/admin.html`, `src/templates/base/admin-login.html`.
- Validation run: `node run-linter.js src/virtual-hosts.js` (pass); `node run-tests.js` (1366 pass); read-through checks confirm the asset route is before `'*'` and no template has direct stylesheet/script URLs or `{{#if build_id}}`.
- Blockers: Manual dev-server and deployed-build checks deferred by repository verification policy.
- Blockers: None.

---

### Task 4: Dev server support for the /assets URL shape

**Status:** Complete
**Depends on:** Task 3
**Documentation:** `README.md` (Development Server), `AGENTS.md` (Development Server)

**Objective**

Local development exercises the same `/assets/<segment>/...` URLs as production while
still reading CSS and JavaScript straight from `src/stylesheets/` and `src/javascript/`,
so an edit shows up on the next reload with no build step and no server restart.

**Scope**

- In: dev server interception of `/assets/**`, and the README/AGENTS notes describing it.
- Out: setting `BUILD_ID` on the child process (see below), any change to the app server's
  own handlers, any asset build or bundling step, and unit tests (see **Test coverage** below).

**Design and invariants**

- **Do not set `BUILD_ID` on the app server child to make this work.** The same Build ID
  namespaces the page data store, the template file store, and the Hyperview page cache, so
  a synthetic Build ID in development would send every page lookup to
  `src/pages/<build-id>/` and 404 the entire site. The dev server must fake the Build ID at
  the URL layer only, which is exactly what Task 2's placeholder allows.
- The dev server strips the `/assets/` prefix **and the following Build ID segment**,
  whatever its value, then dispatches the remainder to the existing source-file handlers:
  a remaining path under `stylesheets/` is served from `src/stylesheets/`, and one under
  `javascript/` from `src/javascript/`. The segment's value is ignored entirely — there is
  no build to distinguish in development.
- Keep the existing bare `/stylesheets/` and `/javascript/` prefixes working. They cost
  nothing, and they stay useful for opening a source file directly in a browser.
- Reuse `validatePathname()` and the existing resolved-path root check in
  `tools/devserver/stylesheet-file-handler.js:44-60` rather than writing a third copy of the
  traversal guard.
- **Dev must keep responding `cache-control: no-cache`.** The production handler now sends
  a one-year immutable policy; if the dev server ever echoed that, an edited stylesheet
  would be invisible for a year behind the browser cache. This is the single most important
  behavioral difference between the two paths.
- Interception happens before the proxy hop, alongside the existing checks in
  `tools/devserver.js:64-88`, so an asset request never restarts or waits on the app
  server child.

**Test coverage**

No unit tests. Nothing under `tools/` is covered by the unit suite today, and the dev server's
behavior is defined by Node `http` request and response objects that would need substantial
faking to assert against — the harness cost would exceed the value for code that never ships
to a deploy target. The manual checks below are the verification for this task; run all of
them, including the edit-and-reload check, since the caching mistake this task guards against
is invisible to a single `curl`.

If coverage here ever becomes worthwhile, the testable seam is the prefix-stripping function
(pathname in, `{ root, key }` or `null` out), which is pure and could be extracted and tested
without touching the HTTP layer. Do not extract it speculatively as part of this task.

**Expected touch points**

- `tools/devserver/stylesheet-file-handler.js` and/or `tools/devserver/javascript-file-handler.js` — accept the `/assets/<segment>/` prefixed form, or expose the pieces a shared matcher needs.
- `tools/devserver.js` — dispatch `/assets/**` to the source-file handlers.
- `README.md` and `AGENTS.md` — note that the dev server serves the `/assets/**` shape from source and ignores the Build ID segment.

Treat this list as orientation, not permission to ignore other necessary files. Record the
actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] `/assets/dev/stylesheets/stylesheet.css` is served from `src/stylesheets/stylesheet.css` without proxying to the app server.
- [ ] `/assets/dev/javascript/site.js` is served from `src/javascript/site.js`.
- [ ] Any Build ID segment value works identically in development.
- [ ] The bare `/stylesheets/**` and `/javascript/**` prefixes still work.
- [ ] Dev responses carry `cache-control: no-cache`, never the immutable policy.
- [ ] A traversal attempt under `/assets/**` is a 400, and a missing file is a 404.
- [ ] Non-GET/HEAD methods still produce 405 with an `Allow` header.

**Validation**

- `node run-linter.js tools/devserver.js tools/devserver/` — no lint errors.
- Manual, with `node tools/devserver.js --port 2026` running:
  - `curl -sI http://localhost:2026/assets/dev/stylesheets/stylesheet.css` → 200, `content-type: text/css`, `cache-control: no-cache`.
  - `curl -sI http://localhost:2026/assets/anything/javascript/site.js` → 200.
  - `curl -sI http://localhost:2026/stylesheets/stylesheet.css` → 200 (legacy prefix still works).
  - `curl -sI 'http://localhost:2026/assets/dev/stylesheets/../../../package.json'` → 400.
  - `curl -sI -X POST http://localhost:2026/assets/dev/stylesheets/stylesheet.css` → 405.
  - Load `http://localhost:2026/` in a browser, edit a rule in `src/stylesheets/stylesheet.css`, reload, and confirm the change appears without restarting the dev server.

**Progress and handoff**

- Completed: Added development-server interception for `/assets/<segment>/stylesheets/**` and `/assets/<segment>/javascript/**`, stripping the URL envelope before dispatching to existing source-file handlers. Documented the behavior in both development-server guides.
- Current state: Complete, except for the plan's dev-server manual checks, which were not run because repository instructions prohibit dev-server/smoke verification unless explicitly requested.
- Remaining: None.
- Decisions and discoveries: The raw request path is used before dispatch so `validatePathname()` can reject dot-segment traversal instead of URL normalization collapsing it first. Existing source-file handlers retain the root check, `no-cache`, 404, and 405 behavior; bare source prefixes remain unchanged.
- Actual files changed: `tools/devserver.js`, `README.md`, `AGENTS.md`.
- Validation run: `node run-linter.js tools/devserver.js tools/devserver/` (pass); `git diff --check` (pass).
- Blockers: Manual curl/browser checks deferred by repository verification policy.
- Blockers: None.
