### PR TITLE
Improvement page caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,4 +248,4 @@ Run the linter according to the instructions in the `README.md` for every JavaSc
 
 ### Testing
 
-Follow the unit testing guide at test/unit/README.md and follow the instructions in `README.md` for running unit tests. When you discover broken unit tests; think carefully about the correctness if the implementation. If the unit tests need to be updated to match the intended behavior of the implementation then update the unit tests. Otherwise fix the implementation to address the issue that broken tests have highlighted.
+Follow the unit testing guide at test/unit-tests/README.md and follow the instructions in `README.md` for running unit tests. When you discover broken unit tests; think carefully about the correctness if the implementation. If the unit tests need to be updated to match the intended behavior of the implementation then update the unit tests. Otherwise fix the implementation to address the issue that broken tests have highlighted.

--- a/agents/plans/batch-partial-template-manifest-implementation-plan.md
+++ b/agents/plans/batch-partial-template-manifest-implementation-plan.md
@@ -1,0 +1,330 @@
+# Batch Partial Template Manifest Implementation Plan
+
+## Implementation Approach
+
+Replace per-file partial-template publishing with one complete-set `PUT` and make that batch the portable operation exposed by Hyperview. The shared contract will remove `putPartial()` in favor of `putPartials(context, namespace, partials)`, require a non-empty namespace for writes, and define successful replacement and return-value semantics without promising transactional recovery after a failed write or ordering concurrent writes.
+
+The two platform adapters will preserve their natural storage layouts. Cloudflare will store a namespaced build's complete partial set in one JSON value at `{buildId}/partials.json` and load it with one cacheable `get()`; Node will keep individual files under `{root}/{buildId}/partials/` and replace only that directory. Un-namespaced reads retain their existing filesystem traversal or KV `list()` plus `get()` behavior. A missing namespaced set is an invariant failure on both platforms, while an explicitly published empty set reads as `[]`. Legacy namespaced partial keys are neither read, migrated, backfilled, nor deleted.
+
+The Publishing API will expose `PUT /publishing-api/v1/templates/partials{/}` as a JSON:API `PartialTemplateSet` replacement endpoint. It will reuse the existing template permission and Build ID safety rules, require a valid `Content-Length` no greater than 25 MiB as a fast rejection path, enforce the same limit against bytes consumed while buffering, normalize and validate the whole collection through a dedicated Form, and return only normalized file references. Base and page templates remain per-file resources. The old partial wildcard endpoint and all single-partial application methods will be removed.
+
+Cross-cutting constraints:
+
+- External prerequisite: the Kixx deployment/publishing tooling must serialize partial-set writes for one Build ID and wait for the replacement request to succeed before deploying that Build ID. This repository does not contain that client and this plan does not establish its ordering behavior. The owning external repository is not identified anywhere in `kixx-framework/kixx`; it must be assigned and verified before rollout. No lock, version check, or separate seal endpoint will be added here.
+- Sequential replacements of a staged Build ID remain allowed; writes to the current live Build ID remain forbidden.
+- Source strings are ordinary UTF-8 JSON strings and are preserved after JSON decoding. Sources are not trimmed or Base64-encoded.
+- The declared `Content-Length` check rejects missing, malformed, negative, or oversized declarations before body consumption. Because parsing JSON already requires the complete document, the handler also counts streamed bytes while buffering and rejects an understated body that crosses the limit. The preflight check avoids buffering a body already known to be oversized; the streaming count is the authoritative limit.
+- Unit tests and linting are required. Existing E2E tests are not updated or run by this plan.
+- No dependency installation, development server, remote smoke test, migration, or new API documentation guide is in scope.
+
+### Task BPTM-1: Establish the complete partial-set port and Hyperview service contract
+
+**Status:** Complete
+**Depends on:** None
+**Documentation:** `src/plugins/README.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `src/kixx/hyperview/template-file-store-interface.js`
+
+**Objective**
+
+Make complete-set partial publication the only shared write capability exposed by Hyperview, so application code cannot publish a single partial or bypass the build-level replacement invariant.
+
+**Scope**
+
+- In: Update the template-file-store interface types and invariants; replace `HyperviewService.putPartial()` with `putPartials()`; validate service inputs and the non-current Build ID; return written logical file references in submitted order; update Hyperview service unit tests and test doubles.
+- Out: Platform storage encodings, HTTP payload parsing, Forms, routes, transaction scripts, and E2E tests.
+
+**Design and invariants**
+
+- `putPartials(context, namespace, partials)` accepts an array of `{ filepath, source }` entries whose filepaths are relative to `partials/`.
+- A write namespace is mandatory and non-empty. Read methods retain their existing optional namespace convention.
+- A successful call replaces the namespace's complete logical partial set and resolves to `{ filepath }[]` using prefix-included logical paths such as `partials/website/nav.html`, in submitted order. An empty input resolves to `[]`.
+- The contract promises the exact set only after successful resolution. A failed write may leave an incomplete staged namespace, which must be retried or abandoned.
+- Concurrent calls for one namespace are outside the contract; callers must serialize them.
+- `getPartials()` keeps its existing `{ filepath, source }[]` return shape and unspecified listing order.
+- For namespaced reads, a never-published partial set is an invariant failure; an explicitly published empty set returns `[]`. Un-namespaced absence continues to return `[]`.
+- `HyperviewService` remains the owner of the rule that a template write must target a valid Build ID other than the current runtime Build ID. It asserts the canonical normalized filepath and non-empty source of every entry before delegating once.
+- Remove the single-partial method rather than retaining an internal compatibility path.
+
+**Expected touch points**
+
+- `src/kixx/hyperview/template-file-store-interface.js` — replace the single-write property, add precise batch input/result types, and document replacement, namespace, failure, and concurrency guarantees.
+- `src/kixx/hyperview/hyperview-service.js` — replace `putPartial()` with the batch service method and preserve live-build protection.
+- `test/unit-tests/kixx/hyperview/hyperview-service.test.js` — cover delegation, ordering, empty input, canonical input assertions, source assertions, required Build ID, and current-build rejection.
+- Other unit-test doubles implementing `TemplateFileStoreInterface` — rename the removed method where required to keep tests structurally valid.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] No production Hyperview or port API exposes `putPartial()`.
+- [ ] `putPartials()` accepts only a namespaced complete set, delegates once, and returns prefix-included references in input order.
+- [ ] Empty-set publication and successful replacement semantics are documented without promising failure atomicity or concurrent-write ordering.
+- [ ] Namespaced unpublished-set failure versus explicitly empty-set success is part of the portable read contract.
+- [ ] Hyperview service unit tests cover the new method's success and invariant failures.
+
+**Validation**
+
+- `node run-linter.js src/kixx/hyperview/template-file-store-interface.js src/kixx/hyperview/hyperview-service.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — validates changed contract, service, and tests.
+- `node run-tests.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — proves the service-level batch contract and build protections.
+- `rg -n "putPartial\\(" src test/unit-tests --glob '*.js'` — identifies any single-partial production path or stale unit-test double remaining for later tasks.
+
+**Progress and handoff**
+
+- Completed: Replaced `putPartial()` with `putPartials(context, namespace, partials)` across the shared interface documentation and `HyperviewService`. Updated the interface's namespace contract to require a non-empty namespace for `putPartials()` while keeping it optional elsewhere, documented complete-replacement/empty-set/failure/concurrency semantics for the write, and documented the unpublished-vs-explicitly-empty read distinction for `getPartials()`. Added a `PartialInput` typedef. `HyperviewService.putPartials()` asserts the input is an array, asserts each entry's `filepath` is canonical and `source` is non-empty, enforces the existing live-build protection via `#assertWritableBuildId()`, and delegates once to the store, returning its result unchanged (store owns prefixing/ordering per adapter contract). Updated `test/unit-tests/kixx/hyperview/hyperview-service.test.js`: renamed the mock store method, and reworked/added cases covering non-canonical filepath rejection, forwarding of canonical batches, single delegation with returned order, empty-set delegation, empty-source rejection, and current-build rejection.
+- Current state: Complete. All acceptance criteria met.
+- Remaining: None for this task.
+- Decisions and discoveries: The batch port is justified by different platform storage costs and layouts; it expresses a portable application operation rather than a Cloudflare-only seal hint. `assertMatches` in `kixx-assert` uses `String.includes()` for plain-string matchers (not regex), so no escaping is needed for message-substring assertions like `partials[].source`. Confirmed via `rg` that remaining `putPartial(` references live only in the Node/Cloudflare adapters, their unit tests, and `put-template.js`/its test — all explicitly out of scope for BPTM-1 and owned by BPTM-2/BPTM-3.
+- Actual files changed:
+  - `src/kixx/hyperview/template-file-store-interface.js`
+  - `src/kixx/hyperview/hyperview-service.js`
+  - `test/unit-tests/kixx/hyperview/hyperview-service.test.js`
+- Validation run:
+  - `node run-linter.js src/kixx/hyperview/template-file-store-interface.js src/kixx/hyperview/hyperview-service.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — clean.
+  - `node run-tests.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — 37/37 passed.
+  - `rg -n "putPartial\(" src test/unit-tests --glob '*.js'` — only BPTM-2/BPTM-3-owned files remain (adapters, adapter tests, `put-template.js`, `put-template.test.js`).
+- Blockers: None.
+
+### Task BPTM-2: Implement authoritative namespaced partial sets in both platform adapters
+
+**Status:** Complete
+**Depends on:** BPTM-1
+**Documentation:** `src/plugins/README.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `src/kixx/hyperview/template-file-store-interface.js`
+
+**Objective**
+
+Make namespaced partial reads complete and cacheable on Cloudflare while preserving Node's inspectable filesystem layout and giving both adapters identical observable replacement and missing-set behavior.
+
+**Scope**
+
+- In: Implement `putPartials()` and revised `getPartials()` in the Cloudflare and Node template-file-store adapters; remove their `putPartial()` implementations; update adapter unit tests and mocks.
+- Out: Publishing API parsing and validation, application transaction scripts, route changes, legacy data migration, cleanup of legacy KV keys, and E2E tests.
+
+**Design and invariants**
+
+- Cloudflare namespaced writes create one value at `{namespace}/partials.json`. The JSON object maps prefix-included logical keys to source strings, for example `{ "partials/nav.html": "<nav/>" }`.
+- A valid manifest is a plain JSON object whose own enumerable keys are canonical, lower-case logical filepaths beginning with exactly one `partials/` prefix and whose values are non-empty source strings. Nested objects, arrays, null values, non-string sources, non-canonical keys, keys outside `partials/`, and traversal or empty path segments are invariant failures.
+- The Cloudflare adapter validates manifest structure but never trims, folds case, rewrites prefixes, or otherwise normalizes manifest keys or source values. Canonicalization belongs to the publishing edge; the adapter rejects violations of that internal contract.
+- Cloudflare does not also write individual `{namespace}/partials/...` keys and does not list or delete legacy keys. Replacing the manifest replaces the logical set.
+- Cloudflare namespaced reads call `kvStore.get(manifestKey, { type: 'json', cacheTtl })` once, using the existing configured namespaced TTL and default of 86400 seconds. They never fall back to `list()` when the manifest is absent.
+- A missing or structurally invalid namespaced manifest is an unexpected invariant failure. `{}` is valid and maps to `[]`.
+- Cloudflare un-namespaced reads retain the existing `list()` plus bulk `get()` implementation and shorter TTL behavior, including its current legacy limits; expanding that path is out of scope.
+- Node writes individual files beneath `{root}/{namespace}/partials/`. On each successful batch it removes only that directory, recreates it, and writes the complete submitted set. Base templates, page templates, and other build data are untouched.
+- Node creates an empty `partials/` directory for an empty batch. A missing namespaced directory is an invariant failure; a missing un-namespaced directory remains `[]`.
+- Neither adapter promises rollback after a failed replacement or ordering between concurrent replacements.
+- Both adapters assert the port-level input shape at their boundary and return prefix-included file references in submitted order.
+- Adapters translate only recognized backing-store failures into `OperationalError` and preserve the platform error as `cause`: Node filesystem failures other than the explicitly handled `ENOENT` read case, and rejected Cloudflare KV `get()`/`put()` operations after arguments and manifest data have passed adapter assertions. Assertion-library failures and native programmer errors raised by adapter validation or transformation code propagate unchanged. `HyperviewService.putPartials()` does not catch or translate either category.
+
+**Expected touch points**
+
+- `src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js` — add manifest encoding, single-get namespaced reads, required namespaced batch writes, precise manifest-shape invariant checks, no-normalization enforcement, and expected KV rejection translation with preserved cause while preserving the flat fallback.
+- `test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js` — cover exact manifest key/value, one cached JSON read, configured TTL, empty manifest, every invalid manifest shape, rejection rather than normalization, replacement unaffected by legacy keys, return shape, and retained un-namespaced listing.
+- `src/plugins/node-hyperview-template-file-store/lib/template-file-store.js` — replace the namespaced partial directory, distinguish missing namespaced from missing flat directories, and translate expected filesystem failures with preserved cause.
+- `test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — cover complete replacement, omitted-file removal, nested files, empty sets, missing-set behavior, isolation from other template prefixes, and result ordering.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] A Cloudflare namespaced render loads all partial sources through one cacheable JSON `get()` and performs no `list()` or bulk read.
+- [ ] Cloudflare stores only the manifest for new namespaced partial batches and ignores any legacy individual keys.
+- [ ] Node stores individual partial files and removes files omitted by a later successful batch without touching other build content.
+- [ ] Both adapters return `[]` for an explicitly empty set and fail for an unpublished namespaced set.
+- [ ] Un-namespaced reads preserve the pre-change behavior on both adapters.
+- [ ] Adapter tests prove the storage representations, shared observable contract, expected operational failure translation with preserved cause, and unchanged propagation of assertion/programmer errors.
+
+**Validation**
+
+- `node run-linter.js src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js src/plugins/node-hyperview-template-file-store/lib/template-file-store.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — validates both adapters and their tests.
+- `node run-tests.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — proves manifest and filesystem behavior.
+- `rg -n "list\\(" src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js` — manually confirm that listing is reachable only from the un-namespaced fallback.
+
+**Progress and handoff**
+
+- Completed:
+  - **Cloudflare adapter** (`src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js`): Replaced `putPartial()` with `putPartials(context, namespace, partials)`, which requires a non-empty namespace, asserts each entry (non-empty filepath/source, no `..` segments), builds a manifest object keyed by prefix-included logical paths (`partials/<filepath>`), and writes it as one JSON value to `{namespace}/partials.json` via one `kvStore.put()`, wrapped in try/catch translating rejections to `OperationalError` with `cause`. Rewrote `getPartials()` to branch on namespace: empty/null namespace still uses the original `list()` + bulk `get()` flat-keyspace path unchanged; non-empty namespace calls new private `#loadPartialsManifest()`, which does one `kvStore.get(manifestKey, { type: 'json', cacheTtl })` (using the existing `#resolveCacheTtl()` — namespaced default 86400s), asserts the result is not `null` (missing manifest → `AssertionError`, since a namespace must be staged before it's read), then `#parsePartialsManifest()` validates structure: `isPlainObject()` check (rejects arrays/null/non-objects), and per-key validation via new module-level `isValidManifestKey()` (canonical lower-case, starts with `partials/`, non-empty remainder, no empty/`.`/`..` segments) plus `isNonEmptyString()` on each value — any violation throws `AssertionError` naming the manifest key. No normalization is applied to keys or values (verified by a dedicated test). Legacy per-file `{namespace}/partials/...` KV keys are never read, written, or deleted by the new path. Also added `OperationalError` translation (preserving `cause`) to `#getFile()`/`#putFile()` (used by base/page templates) for consistency with the design invariant that only assertion/programmer errors should propagate raw.
+  - **Node adapter** (`src/plugins/node-hyperview-template-file-store/lib/template-file-store.js`): Replaced `putPartial()` with `putPartials(context, namespace, partials)`, which requires a non-empty namespace, resolves each entry's filepath/source (reusing `#resolveFilepath()`/`#resolveKey()`), then does `fsp.rm(prefixDir, { recursive: true, force: true })` followed by `fsp.mkdir(prefixDir, { recursive: true })` and per-entry `mkdir`+`writeFile`, all wrapped in one try/catch translating to `OperationalError` with `cause`. This guarantees complete replacement — a file omitted from a later successful batch no longer exists — and an empty batch still creates an empty `partials/` directory. Rewrote `getPartials()`/replaced `#loadPrefixedFiles()`+`#walkFiles()` with a single `#walkPartialsFiles(dir, safeNamespace, isTopLevel)` that, on `ENOENT` at the top level of a namespaced (non-empty `safeNamespace`) read, throws `AssertionError` ("no published partials directory"); at any other level (top-level flat namespace, or any nested directory during the walk) it returns `[]` as before. File reads during the walk translate non-ENOENT errors to `OperationalError`. Also added the same `OperationalError` translation (preserving `cause`) to `#getFile()`/`#putFile()` (base/page templates) for consistency.
+  - **Adapter unit tests**: Rewrote the `putPartial and getPartials` describe blocks in both `test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js` and `test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` as `putPartials and getPartials`, covering: missing-namespace-read failure, single manifest/replace-directory write + round-trip in submitted order, nested filepaths, explicit empty-set success, complete replacement removing an omitted key/file, isolation from other prefixes/namespaces, namespace-required rejection, and (Cloudflare-only) every invalid manifest shape (non-object, key outside `partials/`, non-lower-case key, empty path segment, non-string/empty value) plus a no-normalization proof test and ignoring legacy per-key data. Updated the Cloudflare test's `makeKVNamespace()` mock `get()` to parse JSON when `{ type: 'json' }` is requested (mirroring real Cloudflare KV behavior), since the manifest round-trips through `JSON.stringify`/`JSON.parse`. Updated one pre-existing TTL test (`applies the TTL to the getPartials bulk read` → `applies the TTL to the getPartials manifest read`) to seed a manifest instead of a legacy per-file key, since namespaced reads no longer use `list()`+bulk `get()`.
+- Current state: Complete. All acceptance criteria met; both adapters share the same observable replacement/missing-set/empty-set contract while using different storage encodings.
+- Remaining: None for this task.
+- Decisions and discoveries: The 25 MiB KV value cap is accepted. No runtime migration or backfill exists, so deployments using the new reader must publish a new partial set before becoming live. Extended `OperationalError` translation to the pre-existing `#getFile()`/`#putFile()` helpers (used by base/page templates, not just partials) in both adapters, because the plan's design invariant ("Adapters translate only recognized backing-store failures into `OperationalError`... Node filesystem failures other than the explicitly handled `ENOENT` read case, and rejected Cloudflare KV `get()`/`put()` operations") reads as adapter-wide rather than partials-only, and no existing test depended on the untranslated raw-error form. `isPlainObject()` from `kixx/assertions/mod.js` already excludes arrays and `null`, so no extra type check was needed beyond it for manifest-shape validation.
+- Actual files changed:
+  - `src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js`
+  - `src/plugins/node-hyperview-template-file-store/lib/template-file-store.js`
+  - `test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js`
+  - `test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js`
+- Validation run:
+  - `node run-linter.js src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js src/plugins/node-hyperview-template-file-store/lib/template-file-store.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — clean.
+  - `node run-tests.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — 89/89 passed.
+  - `rg -n "list\(" src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js` — confirmed `list()` is reachable only from the un-namespaced fallback (`#loadPrefixedFiles`).
+  - `rg -n "putPartial\(" src test/unit-tests --glob '*.js'` — only `src/app/transaction-scripts/publishing/put-template.js` and its test remain, both owned by BPTM-3.
+  - `node run-tests.js test/unit-tests/plugins/node-hyperview-template-file-store/plugin.test.js` — unaffected, still passes (no references to the removed method).
+- Blockers: None.
+
+### Task BPTM-3: Replace the per-file partial Publishing API with complete-set JSON:API publication
+
+**Status:** Complete
+**Depends on:** BPTM-1
+**Documentation:** `src/app/presentation/README.md`; `src/app/transaction-scripts/README.md`; `src/docs/server-error-handling.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `test/unit-tests/README.md`
+
+**Objective**
+
+Expose one authenticated, validated, idempotent collection `PUT` that publishes every partial for a staged build and remove every application path that publishes an individual partial.
+
+**Scope**
+
+- In: Add the batch Form, handler, and transaction script; register the exact optional-trailing-slash route; reuse template authorization; narrow the existing single-template workflow to base/page; remove the wildcard partial route and handler export; add and update unit tests.
+- Out: Adapter storage details, new permissions, a build-finalization endpoint, a public API guide, deployment orchestration code, and E2E execution.
+
+**Design and invariants**
+
+- Route: `PUT /publishing-api/v1/templates/partials{/}`. It must be ordered so the exact collection route cannot be shadowed by broader template or catch-all routes.
+- Authorization remains action `urn:kixx:publishing:template:put` on resource `urn:kixx:publishing:template`.
+- Require `Content-Type: application/vnd.api+json` through the existing JSON:API helper.
+- Require `Content-Length` before consuming the body. Missing uses `BadRequestError` with `httpStatusCode: 411` and code `ContentLengthRequired`; values containing anything other than ASCII decimal digits are malformed (`400`); values above `25 * 1024 * 1024` bytes are `PayloadTooLargeError` (`413`). After the fast header check, buffer through `bufferRequestBodyWithLimit()` so the actual bytes consumed are authoritative and an understated declaration cannot bypass the cap. Decode the bounded bytes as UTF-8 and translate malformed JSON into the same `BadRequestError` contract as `request.json()`.
+- Request resource type is `PartialTemplateSet`. `data.id` is optional; when present it must equal `partials/<Kixx-Build-Id>` or produce the existing JSON:API conflict style.
+- `attributes.partials` is required and must be an array. `[]` is a valid complete empty set. Unknown attributes and entry properties are ignored.
+- Each entry requires `filepath` and `source`. Filepaths are relative to the partial prefix, are not trimmed, and are validated with the same safe-path rules as the retired wildcard route before being folded to lower case. Leading, trailing, and doubled slashes are rejected. A leading literal `partials/` is not stripped and therefore represents a nested relative path.
+- Sources must be non-empty strings, are not trimmed, and are passed through after JSON decoding. Whitespace-only sources remain allowed under the existing non-empty-string rule.
+- Validate the full batch before calling the transaction script. Detect duplicates after normalization and report all applicable field errors through `ValidationError`, using stable nested sources such as `partials[2].filepath`.
+- A dedicated API-only Form owns payload normalization and field validation. A dedicated `publishing/put-partials.js` transaction script owns Build ID input/domain errors and delegates to `HyperviewService.putPartials()` once. Expected adapter infrastructure failures must arrive as an expected `OperationalError` (or a more specific expected project error), and the script may translate them to a publishing-specific `OperationalError` while preserving the original error as `cause`. Assertion-library errors, the project `AssertionError`, and native programmer errors such as `TypeError`, `ReferenceError`, and `SyntaxError` must propagate unchanged; the script must not use a catch-all wrapper.
+- Build ID rules match existing template writes: required, valid, non-reserved, and different from the current runtime Build ID. Sequential replacement while staged is allowed.
+- Remove `partial` from the existing single-template kind set and remove its handler/export/route. Base and page behavior is unchanged.
+- Success is `200 application/vnd.api+json` with type `PartialTemplateSet`, id `partials/<buildId>`, and attributes `{ buildId, partials: [{ filepath }, ...] }`. Paths are kind-relative, normalized, submitted-order references; sources and a redundant count are omitted.
+
+**Expected touch points**
+
+- `src/app/presentation/forms/templates/put-partials-form.js` — own JSON:API batch normalization, validation, duplicate detection, and serialization to service inputs.
+- `src/app/presentation/request-handlers/publishing-api/put-partials.js` — enforce media type and declared size, parse the resource, validate optional identity, invoke the transaction script, and format the summary response.
+- `src/app/transaction-scripts/publishing/put-partials.js` — enforce staged Build ID rules, translate only recognized expected operational write failures with `cause`, and allow programmer/invariant errors to propagate unchanged.
+- `src/app/presentation/request-handlers/publishing-api/put-template.js` — remove the partial handler and retain only base/page single-file behavior.
+- `src/app/transaction-scripts/publishing/put-template.js` — narrow supported kinds to base/page and remove single-partial delegation.
+- `src/app/presentation/request-handlers/publishing-api/mod.js` — export the batch handler and remove the single-partial export.
+- `src/routes/publishing-api-v1.js` — replace the partial wildcard target with the complete-set route and reuse `requireTemplatePermission`.
+- `test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js` — cover shape validation, empty input, unknown fields, exact source preservation, path normalization/rejection, and normalized duplicates.
+- `test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js` — cover media type, strict Content-Length syntax and statuses, declared and actual-byte caps, JSON:API type/id, authorization assumptions, handler delegation, and response shape.
+- `test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js` — cover Build ID rules, one service call, empty sets, result mapping, recognized operational failure translation with preserved cause, and unchanged propagation of assertion and native programmer errors.
+- Existing `put-template` handler and transaction-script unit tests — remove partial cases while proving base/page behavior remains unchanged.
+- Route or authorization unit tests, if existing coverage requires updates — prove the new route retains the existing coarse template permission.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] The only partial publishing route accepts a complete JSON:API set at `/templates/partials` with an optional trailing slash.
+- [ ] The handler rejects missing/malformed/oversized declared lengths before body consumption, rejects an understated body when streamed bytes cross the cap, and uses the agreed 411/400/413 errors.
+- [ ] The Form accepts empty sets, preserves sources, normalizes safe paths, rejects empty segments, and rejects post-normalization collisions without partial writes.
+- [ ] Optional `data.id` is checked against `partials/<buildId>` and the success response uses that same identity with normalized source-free references.
+- [ ] The batch transaction script and Hyperview service forbid writes to the live build and allow sequential staged replacements.
+- [ ] No application route, handler, transaction script, or service retains single-partial publication.
+- [ ] Base and page template publishing remains behaviorally unchanged.
+- [ ] Unit tests cover all success and error branches described above.
+
+**Validation**
+
+- `node run-linter.js src/app/presentation/forms/templates/put-partials-form.js src/app/presentation/request-handlers/publishing-api/put-partials.js src/app/presentation/request-handlers/publishing-api/put-template.js src/app/transaction-scripts/publishing/put-partials.js src/app/transaction-scripts/publishing/put-template.js src/app/presentation/request-handlers/publishing-api/mod.js src/routes/publishing-api-v1.js test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js test/unit-tests/app/transaction-scripts/publishing/put-template.test.js` — validates the Publishing API implementation and unit tests.
+- `node run-tests.js test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js test/unit-tests/app/transaction-scripts/publishing/put-template.test.js` — proves payload, workflow, and retained base/page behavior.
+- `rg -n "putPartialTemplate|putPartial\\(" src/app src/routes --glob '*.js'` — must return no retired application publishing path.
+
+**Progress and handoff**
+
+- Completed:
+  - **`src/app/presentation/forms/templates/put-partials-form.js`** (new, API-only form): `PutPartialsForm` normalizes each `{filepath, source}` entry (fold `filepath` to lower case only when it already passes the safe-path check; `source` is never touched), preserves invalid input for `validate()`, and validates: overall `partials` array shape, per-entry safe/non-empty `filepath` (reusing `isValidPathname()` from `kixx/utils/validate-pathname.js` plus a local empty-path-segment check for leading/trailing/doubled slashes, since JSON:API input arrives as one string rather than pre-split route segments), non-empty `source`, and post-normalization duplicate `filepath` collisions — reporting every applicable error via `ValidationError` with sources like `partials[2].filepath`. `toJSON()` returns `{ partials }`. `fromJsonApi(resource)` reads `resource.attributes`.
+  - **`src/app/presentation/lib/json-api.js`** (refactored, not just extended): split `parseJsonApiResource(request, expectedType)` into a thin wrapper around a new exported `resourceFromJsonApiDocument(document, expectedType)`, which owns the actual JSON:API envelope validation (data object, `type`, `attributes`). This lets the new handler decode its own size-capped, buffered body and still reuse the exact same envelope-validation contract instead of duplicating it. `parseJsonApiResource()`'s external behavior/signature is unchanged, and its own error-shape is verified by the full unit suite (1505/1505 passing) since several other handlers depend on it.
+  - **`src/app/presentation/request-handlers/publishing-api/put-partials.js`** (new handler): calls `assertJsonApiContentType()`, then a local `assertDeclaredContentLength()` that requires `Content-Length` (`BadRequestError`, `httpStatusCode: 411`, `code: 'ContentLengthRequired'` when missing; `code: 'ContentLengthInvalid'`/400 when it contains anything other than `^[0-9]+$`; `PayloadTooLargeError`/413 when the declared value exceeds `25 * 1024 * 1024`) — all before touching the body. It then calls the existing `bufferRequestBodyWithLimit()` (unchanged, already enforces the same cap against actually-streamed bytes, so an understated declaration still gets caught), decodes the buffered bytes with a fatal UTF-8 `TextDecoder` + `JSON.parse` inside a try/catch that rethrows as `BadRequestError('Invalid JSON in request body', { cause })` (matching `ServerRequestInterface#json()`'s exact message), parses the resource via `resourceFromJsonApiDocument(document, 'PartialTemplateSet')`, checks an optional `data.id` against `partials/<buildId>` (`ConflictError`, `code: 'JsonApiResourceIdMismatch'` on mismatch), builds and validates a `PutPartialsForm`, calls the new transaction script, and responds `200` with `{ type: 'PartialTemplateSet', id: 'partials/<buildId>', attributes: { buildId, partials: written } }` — `written` entries carry only `{ filepath }` (no `source`), so sources are never echoed back.
+  - **`src/app/transaction-scripts/publishing/put-partials.js`** (new script): validates `buildId` is present/valid/non-reserved and differs from the current runtime build id (`BadRequestError`/`ConflictError`, mirroring `put-template.js`'s existing rules), then delegates once to `context.getService('Hyperview').putPartials(context, buildId, partials)`. Unlike `put-template.js`'s catch-all `try { } catch (cause) { throw new AssertionError(...) }`, this script's catch checks `cause.expected` and only translates *expected* failures (`OperationalError`, or any error with `expected: true`) into a publishing-specific `OperationalError` with `cause` preserved; anything else (an `AssertionError`, `TypeError`, etc.) rethrows unchanged, per the plan's explicit "must not use a catch-all wrapper" instruction for this script.
+  - **`src/app/presentation/request-handlers/publishing-api/put-template.js`**: removed `putPartialTemplate` (and the `'partial'` call to `createPutTemplateHandler`); updated the shared JSDoc block to describe only base/page and point to `put-partials.js` for partials.
+  - **`src/app/transaction-scripts/publishing/put-template.js`**: `TEMPLATE_KINDS` narrowed to `Set(['base', 'page'])`; removed the `service.putPartial(...)` branch; updated JSDoc (`@param {'base'|'page'}`, updated assertion message to "kind must be base or page").
+  - **`src/app/presentation/request-handlers/publishing-api/mod.js`**: exports `putBaseTemplate, putPageTemplate` (dropped `putPartialTemplate`) and adds `export { putPartials } from './put-partials.js'`.
+  - **`src/routes/publishing-api-v1.js`**: replaced the `/templates/partials/*filepath` wildcard route with `PUT /templates/partials{/}` (exact collection route, optional trailing slash, reuses `Permissions.requireTemplatePermission`), wired to `PublishingAPI.putPartials`.
+  - **Tests**: added `test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js` (11 tests: empty set, source preserved untrimmed, case-folding, unknown-field stripping, shape/missing-field/traversal/leading-trailing-doubled-slash/disallowed-character rejection, multi-error reporting, post-normalization duplicate detection); `test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js` (18 tests, modeled on the existing `put-static-asset.test.js` streaming-body pattern: successful write/response shape, empty-set, `data.id` match/mismatch, resource-type mismatch, media-type rejection, all three Content-Length failure modes including a real `MAX_PARTIALS_BYTES + 1`-byte body for the understated-length/streaming-cap case, malformed-JSON body, Form-validation rejection, build-id rules); `test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js` (9 tests: build-id rules, single delegation with submitted-order-preserving result, empty set, first-deploy-without-current-build, expected-failure→`OperationalError` translation with preserved `cause`, and unchanged propagation of both an `AssertionError`-named error and a native `TypeError`). Updated the existing `put-template.js` handler and transaction-script tests to drop the `'partial'` kind/`putPartial`/`putPartialTemplate` scenarios (rewired the "current build" and "nested segments" cases onto `page`/`putPageTemplate` instead, since removing `partial` outright would have deleted meaningful coverage) — 17 and 8 tests respectively, all still green.
+- Current state: Complete. All acceptance criteria met.
+- Remaining: None for this task.
+- Decisions and discoveries: Existing Forms ignore fields they do not own; the batch Form follows that convention. The project has no dedicated 411 error class, so the handler uses a scoped `BadRequestError` status override (`httpStatusCode: 411`), which `WrappedError`'s constructor supports directly via `options.httpStatusCode`. Refactoring `parseJsonApiResource()` into a thin wrapper over the new `resourceFromJsonApiDocument()` was necessary (not just convenient) because the handler must buffer the body itself to enforce the byte cap before any JSON parsing happens — it cannot call `request.json()` a second time after `bufferRequestBodyWithLimit()` has already consumed the one-shot body stream. This is a pure refactor with no behavior change to `parseJsonApiResource()`'s existing signature/contract, confirmed by the full unit suite passing unchanged.
+- Actual files changed:
+  - `src/app/presentation/forms/templates/put-partials-form.js` (new)
+  - `src/app/presentation/request-handlers/publishing-api/put-partials.js` (new)
+  - `src/app/transaction-scripts/publishing/put-partials.js` (new)
+  - `src/app/presentation/lib/json-api.js`
+  - `src/app/presentation/request-handlers/publishing-api/put-template.js`
+  - `src/app/transaction-scripts/publishing/put-template.js`
+  - `src/app/presentation/request-handlers/publishing-api/mod.js`
+  - `src/routes/publishing-api-v1.js`
+  - `test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js` (new)
+  - `test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js` (new)
+  - `test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js` (new)
+  - `test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js`
+  - `test/unit-tests/app/transaction-scripts/publishing/put-template.test.js`
+- Validation run:
+  - `node run-linter.js <all files listed above>` — clean.
+  - `node run-tests.js <all new/changed test files listed above>` — 63/63 passed.
+  - `rg -n "putPartialTemplate|putPartial\(" src/app src/routes --glob '*.js'` — no matches (exit 1).
+  - `node run-tests.js` (full repo unit suite) — 1505/1505 passed, confirming the `json-api.js` refactor and route change did not regress any other caller.
+  - `git diff --check` — clean.
+- Blockers: None.
+
+### Task BPTM-4: Complete repository-wide unit verification and stale-contract cleanup
+
+**Status:** Complete
+**Depends on:** BPTM-2, BPTM-3
+**Documentation:** `test/unit-tests/README.md`; root `README.md` development commands
+
+**Objective**
+
+Verify the new batch contract and adapter replacement semantics through unit tests, remove stale executable references to the retired endpoint, and validate all changed JavaScript without contacting or starting a deployment target.
+
+**Scope**
+
+- In: Perform a repository-wide production and unit-test stale-reference audit; remove or update stale unit-test fixtures and doubles; run linting and the full unit suite; verify complete replacement in adapter unit tests; record that existing E2E files remain unchanged and the E2E suite was intentionally not run.
+- Out: Editing or running E2E tests, starting the development server, calling a remote server, installing dependencies, adding a migration/backfill, or creating a new API documentation guide.
+
+**Design and invariants**
+
+- Complete replacement, including omitted-file removal, is an adapter-unit-test responsibility. Node tests inspect the resulting namespace directory; Cloudflare tests inspect and reread the replaced manifest while proving legacy keys have no effect.
+- Handler, Form, transaction-script, service, and route unit tests own the JSON:API success and error contract, including authentication middleware placement, strict and understated `Content-Length`, malformed JSON:API, identity conflicts, invalid entries, normalized duplicates, Build ID rules, and empty replacement.
+- Existing partial-template E2E files remain unchanged even though they describe the retired endpoint. They are outside this plan and must not be treated as executable acceptance coverage for the new contract.
+- Final verification runs the linter for every changed JavaScript file and the complete unit suite. It also runs `git diff --check` and a stale-symbol search scoped to production and unit-test JavaScript.
+
+**Expected touch points**
+
+- All files changed by BPTM-1 through BPTM-3 — include them in final linting and stale-reference review.
+
+Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.
+
+**Acceptance criteria**
+
+- [ ] Adapter unit tests prove complete replacement, omitted-file removal, empty replacement, and missing-set behavior for both storage representations.
+- [ ] Existing E2E files are unchanged and the final handoff records that they still describe the retired endpoint and were intentionally neither updated nor run.
+- [ ] No production or unit-test reference to the retired `putPartial()`/`putPartialTemplate` contract remains; existing E2E and historical implementation-plan references are explicitly excluded from this audit.
+- [ ] All changed JavaScript passes linting.
+- [ ] The complete unit suite passes.
+- [ ] No whitespace errors remain.
+
+**Validation**
+
+- `node run-linter.js <every changed JavaScript pathname>` — validates every source and unit-test JavaScript file changed by the implementation.
+- `node run-tests.js` — runs the complete unit suite and proves cross-module compatibility.
+- `git diff --check` — detects whitespace errors in the complete patch.
+- `rg -n "putPartialTemplate|putPartial\\(|templates/partials/\\*filepath" src test/unit-tests --glob '*.js'` — confirms removal of the retired production and unit-test contract without treating unchanged E2E files as in scope.
+- E2E editing and execution: intentionally omitted by explicit user instruction.
+
+**Progress and handoff**
+
+- Completed:
+  - Confirmed adapter unit tests already prove complete replacement, omitted-file/key removal, empty-set publication, and missing-set failure for both storage representations (delivered as part of BPTM-2; re-verified here rather than re-implemented, since that's where the two storage encodings are directly observable).
+  - Ran a repository-wide stale-reference audit: `rg -n "putPartialTemplate|putPartial\(" src/app src/routes --glob '*.js'` (BPTM-3's own check) and the broader `rg -n "putPartialTemplate|putPartial\(|templates/partials/\*filepath" src test/unit-tests --glob '*.js'` (this task's check, covering all of `src/` and `test/unit-tests/`, not just the publishing API) — both returned no matches. No stale unit-test fixtures or doubles remained to remove or update beyond what BPTM-1/BPTM-2/BPTM-3 already handled inline.
+  - Confirmed via `git status --short` that no file under `test/end-to-end/` was touched by this implementation; `test/end-to-end/020-publishing-api/put-partial-template.test.js`, `put-partial-template-errors.test.js`, and `test/end-to-end/fixtures/publishing-api/partial-template.html` remain exactly as they were, still describing the retired per-file endpoint. They are explicitly out of scope and were not treated as executable acceptance coverage for the new contract.
+  - Ran the linter over the complete set of files changed across BPTM-1 through BPTM-3 (18 files: 5 new, 13 modified) — clean.
+  - Ran the complete unit suite (`node run-tests.js`, no path arguments) — 1505/1505 tests passed, confirming no cross-module regression (including from the `json-api.js` refactor in BPTM-3, which other handlers besides the new one depend on).
+  - Ran `git diff --check` — no whitespace errors.
+  - Noted one pre-existing, unrelated uncommitted change in `AGENTS.md` (a `test/unit/README.md` → `test/unit-tests/README.md` path-typo fix) that predates this session's work; left untouched since it is not part of this plan.
+- Current state: Complete. All acceptance criteria met.
+- Remaining: None for this task. The plan's four tasks are all complete.
+- Decisions and discoveries: Existing E2E coverage remains unchanged and continues to describe the retired endpoint. Complete replacement is proven at the adapter boundary, where both storage representations are directly observable. The full-suite run (1505 tests) is the strongest signal that the `json-api.js` refactor (splitting `parseJsonApiResource()` into a thin wrapper over `resourceFromJsonApiDocument()`) did not change behavior for any of its other callers.
+- Actual files changed: None (verification-only task; no source or test edits were needed).
+- Validation run:
+  - `node run-linter.js <all 18 files changed by BPTM-1–BPTM-3>` — clean.
+  - `node run-tests.js` (full suite, no path arguments) — 1505/1505 passed.
+  - `git diff --check` — clean.
+  - `rg -n "putPartialTemplate|putPartial\(|templates/partials/\*filepath" src test/unit-tests --glob '*.js'` — no matches.
+  - `git status --short` — confirmed no `test/end-to-end/` file is part of the change set.
+  - E2E editing and execution: intentionally omitted per explicit user/plan instruction; not run.
+- Blockers: The external deployment/publishing tooling repository and owner must be identified, and its serialization/deploy-ordering prerequisite verified, before rollout. This is unchanged from earlier tasks and is outside this repository's scope — it does not block any work performed by this plan, only production rollout of the new contract.

--- a/src/app/presentation/forms/templates/put-partials-form.js
+++ b/src/app/presentation/forms/templates/put-partials-form.js
@@ -1,0 +1,149 @@
+import {
+    isNonEmptyString,
+    isPlainObject,
+    isString,
+} from '../../../../kixx/assertions/mod.js';
+import { ValidationError } from '../../../../kixx/errors/mod.js';
+import { isValidPathname } from '../../../../kixx/utils/validate-pathname.js';
+
+
+/**
+ * Normalizes and validates a complete partial-template-set publication payload.
+ *
+ * Filepaths are relative to the `partials/` prefix and are validated with the
+ * same safe-path rules as the retired per-file wildcard route (no traversal, no
+ * empty/leading/trailing/doubled slash segments, no disallowed characters)
+ * before being folded to lower case to match Hyperview's canonical,
+ * case-insensitive partial addressing. Sources are preserved verbatim after
+ * JSON decoding; neither field is trimmed. An empty `partials` array is a
+ * valid, complete (empty) set.
+ */
+export default class PutPartialsForm {
+
+    /**
+     * JSON Schema for the accepted complete partial-set attributes.
+     * @type {Object}
+     * @static
+     * @readonly
+     */
+    static schema = {
+        type: 'object',
+        properties: {
+            partials: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        filepath: { type: 'string' },
+                        source: { type: 'string' },
+                    },
+                    required: [ 'filepath', 'source' ],
+                },
+            },
+        },
+        required: [ 'partials' ],
+    };
+
+    /**
+     * @param {Object} [attributes] - JSON:API partial-set attributes.
+     * @param {*} [attributes.partials] - Submitted partial entries.
+     */
+    constructor(attributes) {
+        const { partials } = attributes ?? {};
+
+        // Normalize shape only; keep invalid input intact for validate(). A
+        // non-array `partials` is left as-is (rather than coerced to []) so
+        // validate() can report it as a shape error.
+        this.partials = Array.isArray(partials) ? partials.map(normalizePartialEntry) : partials;
+    }
+
+    /**
+     * Validates the normalized partial entries: overall shape, safe non-empty
+     * filepaths, non-empty sources, and post-normalization duplicate filepaths.
+     * An empty `partials` array is valid and reports no errors.
+     * @returns {void}
+     * @throws {ValidationError} When the batch or an entry is invalid.
+     */
+    validate() {
+        const error = new ValidationError('The partial template set contains invalid fields');
+
+        if (!Array.isArray(this.partials)) {
+            error.push('partials must be an array', 'partials');
+            throw error;
+        }
+
+        const seenFilepaths = new Set();
+
+        this.partials.forEach((entry, index) => {
+            const { filepath, source } = entry ?? {};
+            const fieldPrefix = `partials[${ index }]`;
+
+            if (!isValidPartialFilepath(filepath)) {
+                error.push(
+                    'filepath must be a non-empty, safe path relative to partials/',
+                    `${ fieldPrefix }.filepath`,
+                );
+            } else if (seenFilepaths.has(filepath)) {
+                error.push(
+                    `filepath "${ filepath }" collides with another entry after normalization`,
+                    `${ fieldPrefix }.filepath`,
+                );
+            } else {
+                seenFilepaths.add(filepath);
+            }
+
+            if (!isNonEmptyString(source)) {
+                error.push('source is required', `${ fieldPrefix }.source`);
+            }
+        });
+
+        if (error.length) {
+            throw error;
+        }
+    }
+
+    /**
+     * Returns the normalized partial entries consumed by the Transaction Script.
+     * @returns {{ partials: {filepath: string, source: string}[] }} Plain JSON form values.
+     */
+    toJSON() {
+        return { partials: this.partials };
+    }
+
+    /**
+     * Creates the form from a parsed JSON:API resource.
+     * @param {{ attributes: Object }} resource - Parsed resource from resourceFromJsonApiDocument().
+     * @returns {PutPartialsForm} Hydrated partial-set form.
+     */
+    static fromJsonApi(resource) {
+        const { attributes } = resource ?? {};
+        return new PutPartialsForm(attributes);
+    }
+}
+
+function normalizePartialEntry(rawEntry) {
+    const { filepath, source } = isPlainObject(rawEntry) ? rawEntry : {};
+
+    return {
+        // Fold to lower case only when it is safe to do so; validate() reports
+        // an unsafe or non-string filepath rather than this normalization step
+        // silently discarding it.
+        filepath: isString(filepath) && isValidPartialFilepath(filepath) ? filepath.toLowerCase() : filepath,
+        source,
+    };
+}
+
+// A leading, trailing, or doubled slash produces an empty path segment; JSON:API
+// input arrives as one string rather than the pre-split route segments the
+// retired wildcard route validated, so that check is reproduced here.
+function isValidPartialFilepath(filepath) {
+    if (!isNonEmptyString(filepath)) {
+        return false;
+    }
+
+    if (filepath.split('/').some((segment) => segment.length === 0)) {
+        return false;
+    }
+
+    return isValidPathname(filepath);
+}

--- a/src/app/presentation/lib/json-api.js
+++ b/src/app/presentation/lib/json-api.js
@@ -42,9 +42,23 @@ export function assertJsonApiContentType(request) {
  * @throws {ConflictError} When the resource type does not match `expectedType`.
  */
 export async function parseJsonApiResource(request, expectedType) {
-    assertNonEmptyString(expectedType, 'parseJsonApiResource: expectedType');
-
     const document = await request.json();
+    return resourceFromJsonApiDocument(document, expectedType);
+}
+
+/**
+ * Validates an already-parsed JSON:API document and returns the resource id
+ * and attributes. Shared by parseJsonApiResource() and by handlers that must
+ * buffer and decode the request body themselves (for example, to enforce a
+ * byte cap before parsing), so the JSON:API envelope contract is defined once.
+ * @param {*} document - Parsed JSON:API document, typically the result of `JSON.parse()`.
+ * @param {string} expectedType - JSON:API resource type required by the endpoint.
+ * @returns {{ id: string|undefined, attributes: Object }} Parsed resource values.
+ * @throws {BadRequestError} When the JSON:API envelope is malformed.
+ * @throws {ConflictError} When the resource type does not match `expectedType`.
+ */
+export function resourceFromJsonApiDocument(document, expectedType) {
+    assertNonEmptyString(expectedType, 'resourceFromJsonApiDocument: expectedType');
 
     if (!isPlainObject(document) || !isPlainObject(document.data)) {
         throw new BadRequestError('JSON:API request body must contain a data object.');

--- a/src/app/presentation/request-handlers/publishing-api/mod.js
+++ b/src/app/presentation/request-handlers/publishing-api/mod.js
@@ -10,4 +10,5 @@
 export { putPageInclude } from './put-page-include.js';
 export { putPageMetadata } from './put-page-metadata.js';
 export { putStaticAsset } from './put-static-asset.js';
-export { putBaseTemplate, putPageTemplate, putPartialTemplate } from './put-template.js';
+export { putBaseTemplate, putPageTemplate } from './put-template.js';
+export { putPartials } from './put-partials.js';

--- a/src/app/presentation/request-handlers/publishing-api/put-partials.js
+++ b/src/app/presentation/request-handlers/publishing-api/put-partials.js
@@ -1,0 +1,148 @@
+import { isNonEmptyString, isUndefined } from '../../../../kixx/assertions/mod.js';
+import {
+    BadRequestError,
+    ConflictError,
+    PayloadTooLargeError,
+} from '../../../../kixx/errors/mod.js';
+import {
+    BUILD_ID_HEADER,
+    JSON_API_CONTENT_TYPE,
+    assertJsonApiContentType,
+    jsonApiResource,
+    resourceFromJsonApiDocument,
+} from '../../lib/json-api.js';
+import { bufferRequestBodyWithLimit } from '../../lib/read-request-body.js';
+import PutPartialsForm from '../../forms/templates/put-partials-form.js';
+import { putPartials as putPartialsScript } from '../../../transaction-scripts/publishing/put-partials.js';
+
+
+const RESOURCE_TYPE = 'PartialTemplateSet';
+
+// Cloudflare KV values cap at 25 MiB; the whole manifest write must stay under
+// that limit, not each partial individually.
+const MAX_PARTIALS_BYTES = 25 * 1024 * 1024;
+
+const CONTENT_LENGTH_HEADER = 'content-length';
+const DECIMAL_DIGITS_PATTERN = /^[0-9]+$/u;
+
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+
+/**
+ * Replaces the complete partial template set for a build.
+ *
+ * This is the only partial-publishing endpoint: it always replaces the entire
+ * set for the target build in one request rather than writing one partial at a
+ * time. The write is namespaced by the `x-kixx-build-id` request header, so it
+ * lands in the pending build rather than the live one.
+ *
+ * `Content-Length` is required and checked before any body is read; a missing,
+ * malformed, or oversized declaration is rejected without buffering. The
+ * declared length is a fast rejection path only — `bufferRequestBodyWithLimit()`
+ * still enforces the same cap against bytes actually streamed, so an understated
+ * declaration cannot bypass it.
+ *
+ * @param {import('../../../../kixx/context/request-context.js').default} context - Active request context.
+ * @param {import('../../../../kixx/http-router/server-request-interface.js').ServerRequestInterface} request - Incoming request; the body is a JSON:API `PartialTemplateSet` document.
+ * @param {import('../../../../kixx/http-router/server-response.js').default} response - Current response state.
+ * @returns {Promise<import('../../../../kixx/http-router/server-response.js').default>} 200 response summarizing the written partial set.
+ * @throws {UnsupportedMediaTypeError} When the request Content-Type is not `application/vnd.api+json`.
+ * @throws {BadRequestError} When Content-Length is missing/malformed, the body is not valid JSON:API, or an entry fails validation.
+ * @throws {PayloadTooLargeError} When the declared or actual body size exceeds 25 MiB.
+ * @throws {ConflictError} When `data.id` does not match `partials/<buildId>`, or the resource type does not match.
+ */
+export async function putPartials(context, request, response) {
+    assertJsonApiContentType(request);
+    assertDeclaredContentLength(request);
+
+    // Authorization already ran in requireTemplatePermission (route head).
+
+    // buildId is validated downstream by the Transaction Script, which is the
+    // single authority that enforces it (required, valid, and must differ from
+    // the current build).
+    const buildId = request.headers.get(BUILD_ID_HEADER);
+
+    const bodyBytes = await bufferRequestBodyWithLimit(request, MAX_PARTIALS_BYTES);
+    const document = decodeJsonBody(bodyBytes);
+    const resource = resourceFromJsonApiDocument(document, RESOURCE_TYPE);
+
+    assertResourceIdentity(resource, buildId);
+
+    const form = PutPartialsForm.fromJsonApi(resource);
+    form.validate();
+
+    const written = await putPartialsScript(context, {
+        buildId,
+        partials: form.toJSON().partials,
+    });
+
+    // This target's chain has no Hyperview handler after it, so the committed
+    // JSON response is terminal without skip(). Returning normally lets any
+    // route outbound middleware (e.g. response formatting) still run.
+    return response.respondWithJSON(
+        200,
+        jsonApiResource({
+            type: RESOURCE_TYPE,
+            id: `partials/${ buildId }`,
+            attributes: {
+                buildId,
+                partials: written,
+            },
+        }),
+        { contentType: JSON_API_CONTENT_TYPE },
+    );
+}
+
+// Declared Content-Length is a fast rejection path: reject a missing,
+// non-numeric, or oversized declaration before buffering anything.
+// bufferRequestBodyWithLimit() below remains the authoritative cap against
+// bytes actually streamed, since a client's declared length is not trustworthy.
+function assertDeclaredContentLength(request) {
+    const raw = request.headers.get(CONTENT_LENGTH_HEADER);
+
+    if (!isNonEmptyString(raw)) {
+        throw new BadRequestError('A Content-Length header is required for partial template set writes.', {
+            code: 'ContentLengthRequired',
+            httpStatusCode: 411,
+        });
+    }
+
+    if (!DECIMAL_DIGITS_PATTERN.test(raw)) {
+        throw new BadRequestError('Content-Length must be a non-negative integer.', {
+            code: 'ContentLengthInvalid',
+        });
+    }
+
+    const declaredLength = Number.parseInt(raw, 10);
+
+    if (declaredLength > MAX_PARTIALS_BYTES) {
+        throw new PayloadTooLargeError(
+            `Partial template set request body exceeds the maximum of ${ MAX_PARTIALS_BYTES } bytes.`,
+        );
+    }
+}
+
+// Mirrors the BadRequestError contract of ServerRequestInterface#json(), since
+// the body must be decoded from already-buffered bytes here instead of through
+// request.json() (the byte cap must be enforced before JSON parsing).
+function decodeJsonBody(bodyBytes) {
+    try {
+        return JSON.parse(textDecoder.decode(bodyBytes));
+    } catch (cause) {
+        throw new BadRequestError('Invalid JSON in request body', { cause });
+    }
+}
+
+function assertResourceIdentity(resource, buildId) {
+    if (isUndefined(resource.id)) {
+        return;
+    }
+
+    const expectedId = `partials/${ buildId }`;
+
+    if (resource.id !== expectedId) {
+        throw new ConflictError(`JSON:API resource id must be ${ expectedId }.`, {
+            code: 'JsonApiResourceIdMismatch',
+        });
+    }
+}

--- a/src/app/presentation/request-handlers/publishing-api/put-template.js
+++ b/src/app/presentation/request-handlers/publishing-api/put-template.js
@@ -14,9 +14,11 @@ const TEMPLATE_CONTENT_TYPE = 'text/plain';
 /**
  * Writes a base template's source for a build.
  *
- * The three template kinds share one handler shape, differing only in the store
- * prefix the kind implies. The write is namespaced by the `x-kixx-build-id`
- * request header, so it lands in the pending build rather than the live one.
+ * The base and page template kinds share one handler shape, differing only in
+ * the store prefix the kind implies. Shared partial templates are published as
+ * a complete set through `putPartials()` in `put-partials.js` instead of this
+ * per-file handler. The write is namespaced by the `x-kixx-build-id` request
+ * header, so it lands in the pending build rather than the live one.
  *
  * The response filepath is prefix-less, because the URL path already encodes the
  * kind, and folded to lower case, because Hyperview resolves template ids
@@ -37,12 +39,6 @@ export const putBaseTemplate = createPutTemplateHandler('base');
  * @see putBaseTemplate for the shared contract.
  */
 export const putPageTemplate = createPutTemplateHandler('page');
-
-/**
- * Writes a partial template's source for a build.
- * @see putBaseTemplate for the shared contract.
- */
-export const putPartialTemplate = createPutTemplateHandler('partial');
 
 
 function createPutTemplateHandler(kind) {

--- a/src/app/transaction-scripts/publishing/put-partials.js
+++ b/src/app/transaction-scripts/publishing/put-partials.js
@@ -1,0 +1,66 @@
+import { isNonEmptyString } from '../../../kixx/assertions/mod.js';
+import {
+    BadRequestError,
+    ConflictError,
+    OperationalError,
+} from '../../../kixx/errors/mod.js';
+import { validateBuildId } from '../../../kixx/utils/build-id.js';
+
+
+/**
+ * Replaces the complete partial template set for a target build's namespace.
+ *
+ * Delegates once to `HyperviewService.putPartials()`, which enforces the
+ * canonical-filepath and live-build-protection invariants and owns the
+ * complete-replacement contract at the store. This script owns only the
+ * publishing-API-facing Build ID rules and translation of expected write
+ * failures; it does not catch assertion or native programmer errors, which
+ * propagate unchanged so they crash the process rather than being reframed as
+ * an operational failure.
+ * @param {import('../../../kixx/context/request-context.js').default} context - Active request context.
+ * @param {Object} args - Partial set write arguments.
+ * @param {string} args.buildId - Target build id.
+ * @param {{filepath: string, source: string}[]} args.partials - Normalized, validated complete partial set.
+ * @returns {Promise<{filepath: string}[]>} Logical, `partials/`-prefixed filepaths written, in submitted order.
+ * @throws {BadRequestError} When buildId is missing or invalid.
+ * @throws {ConflictError} When buildId targets the current build.
+ * @throws {OperationalError} When the underlying template file store write unexpectedly fails.
+ */
+export async function putPartials(context, args) {
+    const { buildId, partials } = args ?? {};
+
+    if (!isNonEmptyString(buildId)) {
+        throw new BadRequestError('Kixx-Build-Id is required for template writes.', {
+            code: 'BuildIdRequired',
+        });
+    }
+
+    validateBuildId(buildId);
+
+    // A missing current build id means the site has never been deployed; the
+    // first deploy must be able to stage its templates. The equality check below
+    // still protects a live build once one exists, and is vacuously safe when
+    // currentBuildId is null because a non-empty buildId can never equal null.
+    const currentBuildId = context.runtime.build?.id ?? null;
+
+    if (buildId === currentBuildId) {
+        throw new ConflictError('Template writes must target a build other than the current build.', {
+            code: 'CurrentBuildWriteConflict',
+        });
+    }
+
+    const service = context.getService('Hyperview');
+
+    try {
+        return await service.putPartials(context, buildId, partials);
+    } catch (cause) {
+        // Only recognized expected failures (OperationalError and other
+        // error.expected === true errors) are translated here; an AssertionError
+        // or native programmer error propagates unchanged rather than being
+        // caught by a catch-all wrapper, per the project error-handling rules.
+        if (cause.expected) {
+            throw new OperationalError('Failed to publish the partial template set', { cause });
+        }
+        throw cause;
+    }
+}

--- a/src/app/transaction-scripts/publishing/put-template.js
+++ b/src/app/transaction-scripts/publishing/put-template.js
@@ -7,14 +7,16 @@ import {
 import { validateBuildId } from '../../../kixx/utils/build-id.js';
 
 
-const TEMPLATE_KINDS = new Set([ 'base', 'page', 'partial' ]);
+const TEMPLATE_KINDS = new Set([ 'base', 'page' ]);
 
 
 /**
- * Writes a template source file into a non-current build namespace.
+ * Writes a base or page template source file into a non-current build
+ * namespace. Shared partial templates are published as a complete set through
+ * `putPartials()` in `publishing/put-partials.js` instead of this script.
  * @param {import('../../../kixx/context/request-context.js').default} context - Active request context.
  * @param {Object} args - Template write arguments.
- * @param {'base'|'page'|'partial'} args.kind - Template namespace to write.
+ * @param {'base'|'page'} args.kind - Template namespace to write.
  * @param {string} args.filepath - Logical template filepath.
  * @param {string} args.source - Template source text.
  * @param {string} args.buildId - Target build id.
@@ -31,7 +33,7 @@ export async function putTemplate(context, args) {
         buildId,
     } = args ?? {};
 
-    assert(TEMPLATE_KINDS.has(kind), 'putTemplate() kind must be base, page, or partial');
+    assert(TEMPLATE_KINDS.has(kind), 'putTemplate() kind must be base or page');
 
     // An empty body is client input; reject it as a 400 here so it never reaches
     // the template file store, which treats a blank source as a broken invariant
@@ -68,10 +70,7 @@ export async function putTemplate(context, args) {
         if (kind === 'base') {
             return await service.putBaseTemplate(context, buildId, filepath, source);
         }
-        if (kind === 'page') {
-            return await service.putPageTemplate(context, buildId, filepath, source);
-        }
-        return await service.putPartial(context, buildId, filepath, source);
+        return await service.putPageTemplate(context, buildId, filepath, source);
     } catch (cause) {
         throw new AssertionError('Unexpected error while writing a template', { cause });
     }

--- a/src/cloudflare-config.js
+++ b/src/cloudflare-config.js
@@ -49,15 +49,20 @@ export default {
                     },
                 },
             },
+            // Development pins both stores to Cloudflare's 30 second cacheTtl
+            // floor, matching the disabled page and template caches above: edits
+            // should show up on reload, not on a schedule.
             HYPERVIEW_PAGE_DATA_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_PAGE_DATA_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 30,
             },
             HYPERVIEW_TEMPLATE_FILE_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_TEMPLATE_FILE_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 30,
             },
             STATIC_FILE_STORE: {
                 type: 'kv_namespace',
@@ -112,15 +117,20 @@ export default {
                     },
                 },
             },
+            // Page data can be published into the live build's namespace, so its
+            // cacheTtl is the worst-case publish-to-visible delay. Template keys
+            // are immutable within a build and can be cached for a full day.
             HYPERVIEW_PAGE_DATA_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_PAGE_DATA_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 300,
             },
             HYPERVIEW_TEMPLATE_FILE_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_TEMPLATE_FILE_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 86400,
             },
             STATIC_FILE_STORE: {
                 type: 'kv_namespace',
@@ -175,15 +185,20 @@ export default {
                     },
                 },
             },
+            // Page data can be published into the live build's namespace, so its
+            // cacheTtl is the worst-case publish-to-visible delay. Template keys
+            // are immutable within a build and can be cached for a full day.
             HYPERVIEW_PAGE_DATA_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_PAGE_DATA_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 300,
             },
             HYPERVIEW_TEMPLATE_FILE_STORE: {
                 type: 'kv_namespace',
                 bindingName: 'HYPERVIEW_TEMPLATE_FILE_STORE',
                 namespaceId: 'a-kv-namespace-uuid',
+                cacheTtl: 86400,
             },
             STATIC_FILE_STORE: {
                 type: 'kv_namespace',

--- a/src/kixx/hyperview/hyperview-service.js
+++ b/src/kixx/hyperview/hyperview-service.js
@@ -584,25 +584,33 @@ export default class HyperviewService {
     }
 
     /**
-     * Writes a partial template source file to a target build's namespace.
+     * Replaces the complete partial template set for a target build's namespace.
      *
-     * Stores the source verbatim — no compilation — so template syntax and
+     * Stores partial sources verbatim — no compilation — so template syntax and
      * cross-partial references are resolved at render time, not at write time.
+     * A successful call replaces every partial previously published under
+     * `buildId`; a failed call may leave an incomplete set, which the caller
+     * must retry or abandon. Concurrent calls for the same `buildId` are not
+     * ordered by this method — callers must serialize their own writes.
      * @param {RequestContext} context - Request context carrying the current build id
      * @param {string} buildId - Target build id (write namespace); must differ from the current build id
-     * @param {string} filepath - Canonical partial filename relative to `partials/`
-     * @param {string} source - Partial source text to store
-     * @returns {Promise<import('./template-file-store-interface.js').TemplateFileRef>} The logical filepath that was written
-     * @throws {AssertionError} When filepath is not canonical, buildId is empty, or
-     *   buildId matches the current build id
+     * @param {import('./template-file-store-interface.js').PartialInput[]} partials - Complete partial set to publish, with filepaths relative to `partials/`
+     * @returns {Promise<import('./template-file-store-interface.js').TemplateFileRef[]>} Logical, `partials/`-prefixed filepaths that were written, in submitted order
+     * @throws {AssertionError} When partials is not an array, any filepath is not
+     *   canonical, any source is empty, buildId is empty, or buildId matches the
+     *   current build id
      */
-    async putPartial(context, buildId, filepath, source) {
-        assertCanonicalIdentifier(
-            filepath,
-            'HyperviewService.putPartial: filepath',
-        );
+    async putPartials(context, buildId, partials) {
+        assert(Array.isArray(partials), 'HyperviewService.putPartials: partials must be an array');
+        for (const { filepath, source } of partials) {
+            assertCanonicalIdentifier(
+                filepath,
+                'HyperviewService.putPartials: partials[].filepath',
+            );
+            assertNonEmptyString(source, 'HyperviewService.putPartials: partials[].source');
+        }
         this.#assertWritableBuildId(context, buildId);
-        return await this.#templateFileStore.putPartial(context, buildId, filepath, source);
+        return await this.#templateFileStore.putPartials(context, buildId, partials);
     }
 
     /**

--- a/src/kixx/hyperview/hyperview-service.js
+++ b/src/kixx/hyperview/hyperview-service.js
@@ -607,9 +607,14 @@ export default class HyperviewService {
 
     /**
      * Loads and compiles shared partial templates for use by base and page templates.
+     *
+     * When `useCache` is enabled, concurrent callers for the same build share one
+     * load instead of each issuing its own; a failed load is not retained, so a
+     * later call retries. All callers of one shared load resolve to the same map
+     * instance, which they must not mutate.
      * @param {RequestContext} context - Request context
      * @param {Object} [options] - Partial loading options
-     * @param {boolean} [options.useCache=false] - Reuse compiled partials from this service instance
+     * @param {boolean} [options.useCache=false] - Reuse compiled partials, including in-flight loads, from this service instance
      * @returns {Promise<Map<string, Function>>} Partial render functions keyed by canonical
      *   template include name. `get`/`has` fold reference-side lookup keys.
      * @throws {AssertionError} When the store returns a non-canonical partial filepath
@@ -618,20 +623,55 @@ export default class HyperviewService {
         const { useCache = false } = options ?? {};
         const buildId = context.runtime.build?.id ?? null;
 
-        let partials;
         const cacheKey = buildId || 'null';
         if (useCache) {
-            partials = this.#partialsCache.get(cacheKey);
-            if (partials) {
+            const cached = this.#partialsCache.get(cacheKey);
+            if (cached) {
                 this.#logger.debug('template partials cache hit', { key: cacheKey });
-                return partials;
+                return await cached;
             }
             this.#logger.debug('template partials cache miss', { key: cacheKey });
         }
 
+        const pending = this.#compilePartials(context, buildId);
+
+        // Only retain the compiled partials when caching is enabled; otherwise the
+        // map would grow even though no reader ever consults it (the read above is
+        // guarded by useCache), matching getBaseTemplate/getPageTemplate.
+        if (useCache) {
+            // Cache the in-flight promise rather than the resolved map so that
+            // concurrent callers share one load. getBaseTemplate() and
+            // getPageTemplate() both call this and the request handlers run them
+            // through Promise.all, so caching only the resolved value let every
+            // cold-isolate render issue two identical partial loads — which on
+            // Cloudflare KV means two uncacheable list() round trips.
+            this.#partialsCache.set(cacheKey, pending);
+
+            // A rejected load must not stay cached, or one transient storage
+            // failure would be replayed to every later caller for the life of the
+            // isolate. Re-check identity first so a newer successful entry is not
+            // evicted by an older failure.
+            pending.catch(() => {
+                if (this.#partialsCache.get(cacheKey) === pending) {
+                    this.#partialsCache.delete(cacheKey);
+                }
+            });
+        }
+
+        return await pending;
+    }
+
+    /**
+     * Loads and compiles every partial for a build. Split out of loadPartials()
+     * so the cache can hold one promise per build id.
+     * @param {RequestContext} context - Request context
+     * @param {string|null} buildId - Current build id used as the store namespace
+     * @returns {Promise<Map<string, Function>>} Compiled partials keyed by include name
+     */
+    async #compilePartials(context, buildId) {
         const files = await this.#templateFileStore.getPartials(context, buildId);
 
-        partials = new CaseInsensitiveMap();
+        const partials = new CaseInsensitiveMap();
 
         for (const { filepath, source } of files) {
             const name = filepath.replace(/^\/?partials\//, '');
@@ -639,15 +679,10 @@ export default class HyperviewService {
                 name,
                 `HyperviewService.loadPartials: partial filepath ${ filepath }`,
             );
+            // The map is passed to each compile while it is still being filled, so
+            // a partial can reference another partial regardless of load order.
             const template = this.compileTemplate(filepath, source, this.#customHelpers, partials);
             partials.set(name, template);
-        }
-
-        // Only retain the compiled partials when caching is enabled; otherwise the
-        // map would grow even though no reader ever consults it (the read above is
-        // guarded by useCache), matching getBaseTemplate/getPageTemplate.
-        if (useCache) {
-            this.#partialsCache.set(cacheKey, partials);
         }
 
         return partials;

--- a/src/kixx/hyperview/template-file-store-interface.js
+++ b/src/kixx/hyperview/template-file-store-interface.js
@@ -32,13 +32,20 @@
  *   stripped on read by the adapter; it never appears in a returned filepath.
  *
  * ## Namespace contract
- * - `namespace` is optional on every read and write method, positioned as the
- *   second argument (after `context`). Callers pass `null` to opt out.
- * - A `null`, `undefined`, or empty-string `namespace` MUST be treated as "no
- *   namespace" — the flat, unprefixed addressing.
- * - When a non-empty `namespace` is provided it MUST be validated: a non-string
- *   value MUST be rejected, and a value containing `..` path segments MUST be
- *   rejected so a caller cannot escape the namespace.
+ * - `namespace` is positioned as the second argument (after `context`) on
+ *   every read and write method.
+ * - `getBaseTemplate()`, `putBaseTemplate()`, `getPageTemplate()`,
+ *   `putPageTemplate()`, and `getPartials()` treat `namespace` as optional:
+ *   callers pass `null` to opt out, and a `null`, `undefined`, or
+ *   empty-string `namespace` MUST be treated as "no namespace" — the flat,
+ *   unprefixed addressing.
+ * - `putPartials()` requires a non-empty `namespace`. There is no flat,
+ *   unprefixed form of a partial-set write; every batch publishes to one
+ *   build's namespace.
+ * - When a non-empty `namespace` is provided (required or optional) it MUST
+ *   be validated: a non-string value MUST be rejected, and a value
+ *   containing `..` path segments MUST be rejected so a caller cannot escape
+ *   the namespace.
  * - Read and write namespace symmetry is the caller's responsibility: a file
  *   written under one `namespace` is only visible to reads using the same
  *   `namespace`.
@@ -59,15 +66,35 @@
  * - `getBaseTemplate()` and `getPageTemplate()` MUST resolve to `null` when the
  *   template does not exist, and otherwise to a `{ filepath, source }` whose
  *   `filepath` is the logical path with the `namespace` prefix stripped.
- * - The `put*()` methods MUST create or overwrite the file and resolve with the
- *   logical `{ filepath }` that was written (namespace prefix stripped).
+ * - The `putBaseTemplate()` and `putPageTemplate()` methods MUST create or
+ *   overwrite the file and resolve with the logical `{ filepath }` that was
+ *   written (namespace prefix stripped).
+ * - `putPartials(context, namespace, partials)` MUST replace the complete
+ *   partial set for `namespace` in one call: every logical file present under
+ *   `partials/` for that namespace after a successful call MUST be exactly
+ *   the submitted set, and files previously published under that namespace
+ *   but omitted from the submitted set MUST NOT remain readable. It MUST
+ *   resolve to `{ filepath }[]` — logical, `partials/`-prefixed paths with the
+ *   namespace prefix stripped — in the same order as the submitted `partials`
+ *   array. An empty `partials` array is a valid input and MUST resolve to
+ *   `[]`, and MUST still replace (clear) any previously published set for
+ *   that namespace.
+ * - `putPartials()` promises the exact replacement set only after successful
+ *   resolution. It MUST NOT promise recovery of the previous set, or any
+ *   particular intermediate state, after a failed or partial write; a caller
+ *   whose write fails must retry or abandon the namespace. Concurrent
+ *   `putPartials()` calls for the same `namespace` are outside this contract
+ *   — implementations are not required to order them, and callers MUST
+ *   serialize their own writes to one namespace.
  * - `getPartials()` MUST resolve to an array of `{ filepath, source }` for the
  *   files present under the `partials/` prefix for the given `namespace`, with
- *   logical filepaths (namespace prefix stripped). It MUST resolve to an empty
- *   array when none exist, MUST NOT return files from another prefix, and MUST
- *   NOT return files written under a different `namespace`. Listing order
- *   follows the backing store's natural listing order and is not otherwise
- *   guaranteed.
+ *   logical filepaths (namespace prefix stripped). Listing order follows the
+ *   backing store's natural listing order and is not otherwise guaranteed.
+ *   With a non-empty `namespace`, a partial set that was never published by
+ *   `putPartials()` for that namespace is an invariant failure (the namespace
+ *   is expected to have been staged before it is read), while a namespace
+ *   whose published set is explicitly empty MUST resolve to `[]`. With no
+ *   `namespace`, an absent flat partial set MUST resolve to `[]`.
  *
  * ## Context pass-through
  * Every read and write method receives a request or execution `context` as its
@@ -128,11 +155,25 @@
  *   The `filepath` may be nested several segments deep, delimited by `/`.
  *   Resolves with the logical filepath that was written.
  *
- * @property {function(Object, (string|null), string, string): Promise<TemplateFileRef>} putPartial
- *   Creates or overwrites a partial template source file under the `partials/`
- *   prefix. Resolves with the logical filepath that was written.
+ * @property {function(Object, string, PartialInput[]): Promise<TemplateFileRef[]>} putPartials
+ *   Replaces the complete partial template set under the `partials/` prefix
+ *   for the required, non-empty `namespace`. Resolves with the logical,
+ *   `partials/`-prefixed filepaths that were written, in submitted order. An
+ *   empty input replaces the set with an empty set and resolves to `[]`.
  *
  * @property {function(Object, (string|null)): Promise<TemplateFile[]>} getPartials
  *   Retrieves all available partial templates from the `partials/` prefix for
- *   the given namespace. Resolves to an empty array when none exist.
+ *   the given namespace. With a namespace, resolves to `[]` only when that
+ *   namespace's set was explicitly published empty; an unpublished namespace
+ *   is an invariant failure. Without a namespace, resolves to `[]` when none
+ *   exist.
+ */
+
+/**
+ * A partial template source file submitted for batch publication.
+ *
+ * @typedef {Object} PartialInput
+ * @property {string} filepath - Logical filepath relative to `partials/`
+ *   (e.g. `nav.html` or `shared/nav.html`).
+ * @property {string} source - The file's source text.
  */

--- a/src/plugins/cloudflare-document-store-engine/lib/document-store-engine.js
+++ b/src/plugins/cloudflare-document-store-engine/lib/document-store-engine.js
@@ -149,7 +149,9 @@ export default class DocumentStoreEngine {
      *
      * New definitions ensure a generated column backed by `json_extract()` and
      * an accompanying composite index on `(type, col)` both exist. Definitions
-     * that have been removed drop the index then the column. Safe to call on
+     * that have been removed drop the index then the column. Uniqueness changes
+     * are reconciled by dropping and recreating the affected index, and a changed
+     * `jsonPath` by dropping and rebuilding the generated column. Safe to call on
      * every startup — DDL uses IF NOT EXISTS or is guarded by the PRAGMA pre-check.
      *
      * Structured to minimize round trips to D1, because this runs on the first
@@ -691,22 +693,30 @@ export default class DocumentStoreEngine {
      * Reads the current shape of the `documents` table from SQLite introspection.
      *
      * @param {Object} db - D1 database binding
-     * @returns {Promise<{tableExists: boolean, keyColumns: string[], indexUnique: Map<string, boolean>}>}
-     *   Existence of the table, the generated `key_*` column names present on it, and
-     *   the uniqueness flag of every index keyed by index name
-     * @throws {Error} When either PRAGMA query fails
+     * @returns {Promise<{tableExists: boolean, keyColumns: Set<string>, indexUnique: Map<string, boolean>, tableSQL: string}>}
+     *   Existence of the table, the generated `key_*` column names present on it, the
+     *   uniqueness flag of every index keyed by index name, and the stored CREATE TABLE
+     *   text used to recover each generated column's JSON path
+     * @throws {Error} When any introspection query fails
      */
     async #readSchema(db) {
         let tableInfo;
         let indexList;
+        let tableSchema;
 
         try {
-            // Both PRAGMAs are independent read-only introspection queries, so racing
-            // them overlaps their network latency without any ordering hazard. The DDL
+            // All three are independent read-only introspection queries, so racing them
+            // overlaps their network latency without any ordering hazard. The DDL
             // elsewhere in this class is ordered and goes through batch() instead.
-            [ tableInfo, indexList ] = await Promise.all([
+            [ tableInfo, indexList, tableSchema ] = await Promise.all([
                 db.prepare('PRAGMA table_xinfo(documents)').run(),
                 db.prepare('PRAGMA index_list(documents)').run(),
+                // sqlite_master rather than its modern sqlite_schema alias: both work on
+                // D1's SQLite build, but the older name is valid on every version, which
+                // matters here because this path cannot be exercised without a live D1.
+                db.prepare('SELECT sql FROM sqlite_master WHERE type = ? AND name = ?')
+                    .bind('table', 'documents')
+                    .first(),
             ]);
         } catch (cause) {
             throw new Error('Unable to introspect the D1 documents table', { cause });
@@ -729,12 +739,15 @@ export default class DocumentStoreEngine {
             // SQLite returns zero rows rather than an error for a table which does not
             // exist, so the row count doubles as the existence check and saves a query.
             tableExists: columnNames.length > 0,
-            keyColumns: columnNames.filter((name) => name.startsWith('key_')),
+            keyColumns: new Set(columnNames.filter((name) => name.startsWith('key_'))),
             // PRAGMA index_list returns rows like { seq, name, unique, origin, partial };
             // we only need the uniqueness flag keyed by index name.
             indexUnique: new Map(
                 indexList.results.map(({ name, unique }) => [ name, unique === 1 ]),
             ),
+            // SQLite rewrites this stored text as columns are added and dropped, so it is
+            // the only record of the json_extract() path behind each generated column.
+            tableSQL: tableSchema?.sql ?? '',
         };
     }
 
@@ -794,28 +807,51 @@ export default class DocumentStoreEngine {
     #composeMigrationStatements(db, schema) {
         const statements = [];
 
+        // Local copies, because a changed jsonPath removes a column and index which the
+        // checks further down then treat as absent. Mutating the caller's schema would
+        // make it disagree with what the database actually holds until the batch runs.
+        const keyColumns = new Set(schema.keyColumns);
+        const indexUnique = new Map(schema.indexUnique);
+
         for (const indexDefinition of this.#indexDefinitions) {
             const columnName = this.keyToColumnName(indexDefinition.name);
             const indexName = this.keyToIndexName(indexDefinition.name);
             const wantUnique = indexDefinition.unique === true;
             const createIndexSQL = `CREATE ${ wantUnique ? 'UNIQUE ' : '' }INDEX IF NOT EXISTS ${ indexName } ON documents (type, ${ columnName })`;
 
-            if (!schema.keyColumns.includes(columnName)) {
+            if (keyColumns.has(columnName)) {
+                // A generated column's expression cannot be altered in place, so a changed
+                // jsonPath is reconciled by dropping the column and letting the checks below
+                // rebuild it. Without this the column keeps extracting the old path and
+                // queries silently return results derived from stale definitions.
+                const existingJsonPath = getGeneratedColumnJsonPath(schema.tableSQL, columnName);
+                if (existingJsonPath !== indexDefinition.jsonPath) {
+                    statements.push(db.prepare(`DROP INDEX IF EXISTS ${ indexName }`));
+                    statements.push(db.prepare(`ALTER TABLE documents DROP COLUMN ${ columnName }`));
+                    keyColumns.delete(columnName);
+                    indexUnique.delete(indexName);
+                }
+            }
+
+            if (!keyColumns.has(columnName)) {
                 // SQLite restrictions on ALTER TABLE ADD COLUMN:
                 // - Does not support IF NOT EXISTS — so we guard with the PRAGMA check above.
                 // - STORED generated columns cannot be added to a non-empty table; VIRTUAL
                 //   generated columns have no such restriction and are equally indexable.
+                // The jsonPath is quoted as a SQL string literal so an embedded quote cannot
+                // break out of the generated-column expression.
                 statements.push(db.prepare(`
                     ALTER TABLE documents ADD COLUMN ${ columnName }
-                    TEXT GENERATED ALWAYS AS (json_extract(doc, '${ indexDefinition.jsonPath }')) VIRTUAL
+                    TEXT GENERATED ALWAYS AS (json_extract(doc, ${ quoteSqlString(indexDefinition.jsonPath) })) VIRTUAL
                 `));
+                keyColumns.add(columnName);
             }
 
-            if (!schema.indexUnique.has(indexName)) {
+            if (!indexUnique.has(indexName)) {
                 // A previous prepare can crash after adding the column but before
                 // creating the index; reconcile the index independently.
                 statements.push(db.prepare(createIndexSQL));
-            } else if (schema.indexUnique.get(indexName) !== wantUnique) {
+            } else if (indexUnique.get(indexName) !== wantUnique) {
                 // Column survives; index uniqueness flag is reconciled by drop + recreate.
                 // The PRAGMA above reports `unique = 1` for UNIQUE indexes only.
                 statements.push(db.prepare(`DROP INDEX IF EXISTS ${ indexName }`));
@@ -995,6 +1031,31 @@ export default class DocumentStoreEngine {
         return { sql, params };
     }
 
+}
+
+function quoteSqlString(value) {
+    // SQLite escapes an embedded single quote inside a string literal by doubling it.
+    return `'${ String(value).replace(/'/g, "''") }'`;
+}
+
+function unquoteSqlString(value) {
+    return value.slice(1, -1).replace(/''/g, "'");
+}
+
+// Recovers the json_extract() path from the CREATE TABLE text SQLite stores in
+// sqlite_master. The generated-column expression is the only place the path survives;
+// PRAGMA table_xinfo reports the column name and type but not what it extracts.
+function getGeneratedColumnJsonPath(tableSQL, columnName) {
+    const pattern = new RegExp(
+        `\\b${ escapeRegExp(columnName) }\\b\\s+TEXT\\s+GENERATED\\s+ALWAYS\\s+AS\\s*\\(\\s*json_extract\\s*\\(\\s*doc\\s*,\\s*('(?:''|[^'])*')\\s*\\)\\s*\\)\\s+VIRTUAL`,
+        'i',
+    );
+    const match = pattern.exec(tableSQL);
+    return match ? unquoteSqlString(match[1]) : null;
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function getDocumentPayload(doc) {

--- a/src/plugins/cloudflare-document-store-engine/lib/document-store-engine.js
+++ b/src/plugins/cloudflare-document-store-engine/lib/document-store-engine.js
@@ -48,6 +48,11 @@ The D1ExecResult Object:
 
 const DEFAULT_BINDING_NAME = 'DOCUMENT_STORE';
 
+// The built-in index on (type, sort_key) which backs scan(). Unlike the configured
+// secondary indexes it has no generated column, so its presence is the only signal
+// that the initial migration ran to completion.
+const DEFAULT_SORT_KEY_INDEX_NAME = 'idx_type_sort_key';
+
 /**
  * Cloudflare D1 engine adapter for the document store abstraction.
  *
@@ -147,116 +152,55 @@ export default class DocumentStoreEngine {
      * that have been removed drop the index then the column. Safe to call on
      * every startup — DDL uses IF NOT EXISTS or is guarded by the PRAGMA pre-check.
      *
+     * Structured to minimize round trips to D1, because this runs on the first
+     * request served by every cold Worker isolate. Schema introspection happens
+     * first so that all DDL becomes conditional: a database already in the desired
+     * shape costs a single request. Only a database which has never been migrated,
+     * or whose index definitions changed, pays for additional round trips.
+     *
      * @param {Object} context - Cloudflare Workers execution context
      * @returns {Promise<void>}
-     * @throws {Error} When table creation or the PRAGMA introspection query fails
+     * @throws {Error} When table creation, schema reconciliation, or the PRAGMA
+     *   introspection query fails
      */
     async prepareDatabase(context) {
         assertArray(this.#indexDefinitions, 'DocumentStoreEngine#setIndexDefinitions() must be called before the database can be used');
 
         const db = this.#getDatabase(context);
 
-        const createTableSQL = `
-            CREATE TABLE IF NOT EXISTS documents (
-                type       TEXT    NOT NULL,
-                id         TEXT    NOT NULL,
-                sort_key   TEXT,
-                version    INTEGER NOT NULL DEFAULT 1,
-                created_at TEXT    NOT NULL,
-                updated_at TEXT    NOT NULL,
-                doc        TEXT    NOT NULL,
-                PRIMARY KEY (type, id)
-            )
-        `;
+        // A failed read here is deliberately not fatal. A D1 database which has never
+        // been migrated is exactly the case where schema introspection is least
+        // trustworthy, and the create-then-read path below recovers from it. Nothing
+        // is swallowed: if the binding is genuinely unhealthy the CREATE TABLE that
+        // follows fails loudly with its own error.
+        let schema = await this.#readSchema(db).catch((error) => {
+            // The logger prints `info` verbatim, so pass undefined rather than null to
+            // keep the fallback console output clean.
+            this.#logger.debug('schema introspection failed; falling back to create-then-read', undefined, error);
+            return null;
+        });
 
-        const defaultIndexSQL = `
-            CREATE INDEX IF NOT EXISTS idx_type_sort_key
-                ON documents (type, sort_key)
-        `;
-
-        let tableInfo;
-        let indexList;
-        try {
-            await db.prepare(createTableSQL).run();
-            await db.prepare(defaultIndexSQL).run();
-            tableInfo = await db.prepare('PRAGMA table_xinfo(documents)').run();
-            indexList = await db.prepare('PRAGMA index_list(documents)').run();
-        } catch (cause) {
-            throw new Error('Unable to prepare D1 documents table', { cause });
+        // The default index is checked alongside the table because a migration
+        // interrupted between the two would otherwise leave scan() without its index
+        // forever — the table already exists, so a table-only check would skip the fix.
+        if (!schema?.tableExists || !schema.indexUnique.has(DEFAULT_SORT_KEY_INDEX_NAME)) {
+            await this.#createDocumentsTable(db);
+            schema = await this.#readSchema(db);
         }
 
-        if (!tableInfo.success) {
-            throw new Error('Preparing D1 documents table: "PRAGMA table_xinfo(documents)" failed');
-        }
-        if (!indexList.success) {
-            throw new Error('Preparing D1 documents table: "PRAGMA index_list(documents)" failed');
-        }
+        const statements = this.#composeMigrationStatements(db, schema);
 
-        // table_xinfo() is used instead of table_info() because it includes hidden and
-        // generated (VIRTUAL) columns, which table_info() silently omits in some SQLite versions.
-        // │ cid │ name │ type │ notnull │ dflt_value │ pk │ hidden │
-        // We are only interested in the "name"
-        const existingKeyColumns = tableInfo.results
-            .map(({ name }) => name)
-            .filter((name) => name.startsWith('key_'));
-
-        // PRAGMA index_list returns rows like { seq, name, unique, origin, partial };
-        // we only need the uniqueness flag keyed by index name.
-        const existingIndexUnique = new Map(
-            indexList.results.map(({ name, unique }) => [ name, unique === 1 ]),
-        );
-
-        for (const indexDefinition of this.#indexDefinitions) {
-            const columnName = this.keyToColumnName(indexDefinition.name);
-            const indexName = this.keyToIndexName(indexDefinition.name);
-            const wantUnique = indexDefinition.unique === true;
-            const createIndexSQL = `CREATE ${ wantUnique ? 'UNIQUE ' : '' }INDEX IF NOT EXISTS ${ indexName } ON documents (type, ${ columnName })`;
-
-            if (!existingKeyColumns.includes(columnName)) {
-                // SQLite restrictions on ALTER TABLE ADD COLUMN:
-                // - Does not support IF NOT EXISTS — so we guard with the PRAGMA check above.
-                // - STORED generated columns cannot be added to a non-empty table; VIRTUAL
-                //   generated columns have no such restriction and are equally indexable.
-                try {
-                    await db.prepare(`
-                        ALTER TABLE documents ADD COLUMN ${ columnName }
-                        TEXT GENERATED ALWAYS AS (json_extract(doc, '${ indexDefinition.jsonPath }')) VIRTUAL
-                    `).run();
-                } catch (cause) {
-                    throw new Error(`Unable to add index column "${ columnName }" to D1 documents table`, { cause });
-                }
-            }
-
-            if (!existingIndexUnique.has(indexName)) {
-                // A previous prepare can crash after adding the column but before
-                // creating the index; reconcile the index independently.
-                try {
-                    await db.prepare(createIndexSQL).run();
-                } catch (cause) {
-                    throw new Error(`Unable to create index "${ indexName }" on D1 documents table`, { cause });
-                }
-            } else if (existingIndexUnique.get(indexName) !== wantUnique) {
-                // Column survives; index uniqueness flag is reconciled by drop + recreate.
-                // The PRAGMA above reports `unique = 1` for UNIQUE indexes only.
-                try {
-                    await db.prepare(`DROP INDEX IF EXISTS ${ indexName }`).run();
-                    await db.prepare(createIndexSQL).run();
-                } catch (cause) {
-                    throw new Error(`Unable to reconcile uniqueness on index "${ indexName }"`, { cause });
-                }
-            }
-        }
-
-        const desiredIndexKeys = this.#indexDefinitions.map(({ name }) => name);
-        for (const columnName of existingKeyColumns) {
-            const keyName = this.columnNameToKey(columnName);
-            if (!desiredIndexKeys.includes(keyName)) {
-                try {
-                    await db.prepare(`DROP INDEX IF EXISTS ${ this.keyToIndexName(keyName) }`).run();
-                    await db.prepare(`ALTER TABLE documents DROP COLUMN ${ columnName }`).run();
-                } catch (cause) {
-                    throw new Error(`Unable to drop stale index column "${ columnName }" from D1 documents table`, { cause });
-                }
+        if (statements.length > 0) {
+            // batch() runs the statements in order inside an implicit transaction and
+            // costs one round trip for the whole migration. Ordering is load-bearing —
+            // a column must be added before the index referencing it, and an index must
+            // be dropped before its column — so these can never be run concurrently.
+            // The transaction also closes the crash window a statement-at-a-time
+            // migration leaves open, where a column exists without its index.
+            try {
+                await db.batch(statements);
+            } catch (cause) {
+                throw new Error('Unable to reconcile secondary indexes on the D1 documents table', { cause });
             }
         }
 
@@ -741,6 +685,154 @@ export default class DocumentStoreEngine {
         const db = env[bindingName];
         assert(db, `DocumentStoreEngine D1 binding "${ bindingName }" is not bound on context.env`);
         return db;
+    }
+
+    /**
+     * Reads the current shape of the `documents` table from SQLite introspection.
+     *
+     * @param {Object} db - D1 database binding
+     * @returns {Promise<{tableExists: boolean, keyColumns: string[], indexUnique: Map<string, boolean>}>}
+     *   Existence of the table, the generated `key_*` column names present on it, and
+     *   the uniqueness flag of every index keyed by index name
+     * @throws {Error} When either PRAGMA query fails
+     */
+    async #readSchema(db) {
+        let tableInfo;
+        let indexList;
+
+        try {
+            // Both PRAGMAs are independent read-only introspection queries, so racing
+            // them overlaps their network latency without any ordering hazard. The DDL
+            // elsewhere in this class is ordered and goes through batch() instead.
+            [ tableInfo, indexList ] = await Promise.all([
+                db.prepare('PRAGMA table_xinfo(documents)').run(),
+                db.prepare('PRAGMA index_list(documents)').run(),
+            ]);
+        } catch (cause) {
+            throw new Error('Unable to introspect the D1 documents table', { cause });
+        }
+
+        if (!tableInfo.success) {
+            throw new Error('Preparing D1 documents table: "PRAGMA table_xinfo(documents)" failed');
+        }
+        if (!indexList.success) {
+            throw new Error('Preparing D1 documents table: "PRAGMA index_list(documents)" failed');
+        }
+
+        // table_xinfo() is used instead of table_info() because it includes hidden and
+        // generated (VIRTUAL) columns, which table_info() silently omits in some SQLite versions.
+        // │ cid │ name │ type │ notnull │ dflt_value │ pk │ hidden │
+        // We are only interested in the "name"
+        const columnNames = tableInfo.results.map(({ name }) => name);
+
+        return {
+            // SQLite returns zero rows rather than an error for a table which does not
+            // exist, so the row count doubles as the existence check and saves a query.
+            tableExists: columnNames.length > 0,
+            keyColumns: columnNames.filter((name) => name.startsWith('key_')),
+            // PRAGMA index_list returns rows like { seq, name, unique, origin, partial };
+            // we only need the uniqueness flag keyed by index name.
+            indexUnique: new Map(
+                indexList.results.map(({ name, unique }) => [ name, unique === 1 ]),
+            ),
+        };
+    }
+
+    /**
+     * Creates the `documents` table and its built-in `(type, sort_key)` index.
+     *
+     * Both statements use IF NOT EXISTS, so this is safe to run against a database
+     * which is already partially migrated.
+     *
+     * @param {Object} db - D1 database binding
+     * @returns {Promise<void>}
+     * @throws {Error} When either statement fails
+     */
+    async #createDocumentsTable(db) {
+        const createTableSQL = `
+            CREATE TABLE IF NOT EXISTS documents (
+                type       TEXT    NOT NULL,
+                id         TEXT    NOT NULL,
+                sort_key   TEXT,
+                version    INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT    NOT NULL,
+                updated_at TEXT    NOT NULL,
+                doc        TEXT    NOT NULL,
+                PRIMARY KEY (type, id)
+            )
+        `;
+
+        const defaultIndexSQL = `
+            CREATE INDEX IF NOT EXISTS ${ DEFAULT_SORT_KEY_INDEX_NAME }
+                ON documents (type, sort_key)
+        `;
+
+        try {
+            // Ordered batch rather than Promise.all: the index references the table, so
+            // running these concurrently lets D1 attempt the CREATE INDEX first and fail
+            // with "no such table: documents" on a fresh database.
+            await db.batch([
+                db.prepare(createTableSQL),
+                db.prepare(defaultIndexSQL),
+            ]);
+        } catch (cause) {
+            throw new Error('Unable to prepare D1 documents table', { cause });
+        }
+    }
+
+    /**
+     * Builds the ordered list of DDL statements which reconciles the live schema
+     * with `indexDefinitions`.
+     *
+     * Returns an empty array when the schema already matches, which is the steady
+     * state for every isolate after the first migration.
+     *
+     * @param {Object} db - D1 database binding used to prepare the statements
+     * @param {Object} schema - Result of `#readSchema()`
+     * @returns {Object[]} Prepared statements in the order they must execute
+     */
+    #composeMigrationStatements(db, schema) {
+        const statements = [];
+
+        for (const indexDefinition of this.#indexDefinitions) {
+            const columnName = this.keyToColumnName(indexDefinition.name);
+            const indexName = this.keyToIndexName(indexDefinition.name);
+            const wantUnique = indexDefinition.unique === true;
+            const createIndexSQL = `CREATE ${ wantUnique ? 'UNIQUE ' : '' }INDEX IF NOT EXISTS ${ indexName } ON documents (type, ${ columnName })`;
+
+            if (!schema.keyColumns.includes(columnName)) {
+                // SQLite restrictions on ALTER TABLE ADD COLUMN:
+                // - Does not support IF NOT EXISTS — so we guard with the PRAGMA check above.
+                // - STORED generated columns cannot be added to a non-empty table; VIRTUAL
+                //   generated columns have no such restriction and are equally indexable.
+                statements.push(db.prepare(`
+                    ALTER TABLE documents ADD COLUMN ${ columnName }
+                    TEXT GENERATED ALWAYS AS (json_extract(doc, '${ indexDefinition.jsonPath }')) VIRTUAL
+                `));
+            }
+
+            if (!schema.indexUnique.has(indexName)) {
+                // A previous prepare can crash after adding the column but before
+                // creating the index; reconcile the index independently.
+                statements.push(db.prepare(createIndexSQL));
+            } else if (schema.indexUnique.get(indexName) !== wantUnique) {
+                // Column survives; index uniqueness flag is reconciled by drop + recreate.
+                // The PRAGMA above reports `unique = 1` for UNIQUE indexes only.
+                statements.push(db.prepare(`DROP INDEX IF EXISTS ${ indexName }`));
+                statements.push(db.prepare(createIndexSQL));
+            }
+        }
+
+        // Columns left behind by index definitions which have since been removed.
+        for (const columnName of schema.keyColumns) {
+            const keyName = this.columnNameToKey(columnName);
+            if (!this.#indexKeys.includes(keyName)) {
+                statements.push(db.prepare(`DROP INDEX IF EXISTS ${ this.keyToIndexName(keyName) }`));
+                statements.push(db.prepare(`ALTER TABLE documents DROP COLUMN ${ columnName }`));
+            }
+        }
+
+        return statements;
     }
 
     /**

--- a/src/plugins/cloudflare-hyperview-page-data-store/lib/page-data-store.js
+++ b/src/plugins/cloudflare-hyperview-page-data-store/lib/page-data-store.js
@@ -1,10 +1,30 @@
-import { assert, assertNonEmptyString, isObjectNotNull } from '../../../kixx/assertions/mod.js';
+import {
+    AssertionError,
+    assert,
+    assertNonEmptyString,
+    isObjectNotNull,
+    isUndefined,
+} from '../../../kixx/assertions/mod.js';
 
 /**
  * @typedef {import('../../../kixx/context/request-context.js').default} RequestContext
  */
 
 const DEFAULT_BINDING_NAME = 'HYPERVIEW_PAGE_DATA_STORE';
+
+// Page data is the one Hyperview store whose keys are mutable in place: a
+// publish may write page.json and include files into the *current* build's
+// namespace, so this TTL is the worst-case delay before a published edit
+// becomes visible in a network location which already read the key. It also
+// bounds how long a negative lookup for a not-yet-published page is cached,
+// which is the sharper constraint — a newly published page stays 404 in that
+// location until the cached miss expires. Keep it short enough to be an
+// acceptable publish latency; the cold-read savings are already large at a few
+// minutes.
+const DEFAULT_CACHE_TTL_SECONDS = 300;
+
+// Cloudflare KV rejects a cacheTtl below 30 seconds.
+const MIN_CACHE_TTL_SECONDS = 30;
 
 /**
  * Cloudflare KV-backed store for Hyperview page assets.
@@ -18,6 +38,13 @@ const DEFAULT_BINDING_NAME = 'HYPERVIEW_PAGE_DATA_STORE';
  * Callers always work with logical filepaths; the namespace prefix is applied
  * and stripped internally, and keeping the read and write namespaces consistent
  * is the caller's responsibility.
+ *
+ * Reads pass an explicit `cacheTtl` so values stay warm in the network location
+ * they were read from for longer than Cloudflare's 60 second default, which is
+ * what keeps cold-key latency off the page render path. Because a publish can
+ * write into the live build's namespace, the TTL doubles as the publish-to-
+ * visible delay and is configurable through
+ * `config.env.HYPERVIEW_PAGE_DATA_STORE.cacheTtl`.
  *
  * @implements {import('../../../kixx/hyperview/page-data-store-interface.js').PageDataStoreInterface}
  */
@@ -56,9 +83,10 @@ export default class PageDataStore {
         const resolved = filepaths.map((fp) => this.#resolveKey(namespace, fp));
         const kvKeys = resolved.map((r) => r.kvKey);
 
-        this.#logger.debug('getJSONFiles() loading keys', { keys: kvKeys });
+        const cacheTtl = this.#resolveCacheTtl(context);
+        this.#logger.debug('getJSONFiles() loading keys', { keys: kvKeys, cacheTtl });
 
-        const resultMap = await kvStore.get(kvKeys, { type: 'json' });
+        const resultMap = await kvStore.get(kvKeys, { type: 'json', cacheTtl });
 
         return resolved.map(({ logicalKey, kvKey }) => {
             const json = resultMap.get(kvKey) ?? null;
@@ -89,9 +117,10 @@ export default class PageDataStore {
         const resolved = filepaths.map((fp) => this.#resolveKey(namespace, fp));
         const kvKeys = resolved.map((r) => r.kvKey);
 
-        this.#logger.debug('getTextFiles() loading keys', { keys: kvKeys });
+        const cacheTtl = this.#resolveCacheTtl(context);
+        this.#logger.debug('getTextFiles() loading keys', { keys: kvKeys, cacheTtl });
 
-        const resultMap = await kvStore.get(kvKeys, { type: 'text' });
+        const resultMap = await kvStore.get(kvKeys, { type: 'text', cacheTtl });
 
         return resolved.map(({ logicalKey, kvKey }) => {
             const source = resultMap.get(kvKey) ?? null;
@@ -112,9 +141,10 @@ export default class PageDataStore {
     async getTextFile(context, namespace, filepath) {
         this.#logger.debug('getTextFile() loading filepath', { filepath });
         const { kvKey } = this.#resolveKey(namespace, filepath);
-        this.#logger.debug('getTextFile() loading key', { key: kvKey });
+        const cacheTtl = this.#resolveCacheTtl(context);
+        this.#logger.debug('getTextFile() loading key', { key: kvKey, cacheTtl });
         const kvStore = this.#getKVStore(context);
-        const text = await kvStore.get(kvKey, { type: 'text' });
+        const text = await kvStore.get(kvKey, { type: 'text', cacheTtl });
         return text ?? null;
     }
 
@@ -169,6 +199,34 @@ export default class PageDataStore {
         const kvStore = env[bindingName];
         assert(kvStore, `PageDataStore KV binding "${ bindingName }" is not bound on context.env`);
         return kvStore;
+    }
+
+    /**
+     * Resolves the KV read cache TTL in seconds. The namespace is deliberately
+     * not a factor: unlike template files, page data may be written into the
+     * live build's namespace, so namespaced keys are no more immutable than
+     * flat ones.
+     * @param {RequestContext} context - Request context carrying the store config
+     * @returns {number} Cache TTL in seconds
+     * @throws {AssertionError} When a configured cacheTtl is not an integer of at least 30
+     */
+    #resolveCacheTtl(context) {
+        const { config } = context;
+        const { cacheTtl } = config?.env?.HYPERVIEW_PAGE_DATA_STORE ?? {};
+
+        if (isUndefined(cacheTtl) || cacheTtl === null) {
+            return DEFAULT_CACHE_TTL_SECONDS;
+        }
+
+        // A misconfigured TTL is a source-config bug, not user input. Fail loudly
+        // here rather than letting Cloudflare reject the read mid-request.
+        if (!Number.isInteger(cacheTtl) || cacheTtl < MIN_CACHE_TTL_SECONDS) {
+            throw new AssertionError(
+                `PageDataStore "cacheTtl" must be an integer of at least ${ MIN_CACHE_TTL_SECONDS } seconds`,
+            );
+        }
+
+        return cacheTtl;
     }
 
     /**

--- a/src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js
+++ b/src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js
@@ -1,9 +1,13 @@
 import {
     AssertionError,
     assert,
+    assertArray,
     assertNonEmptyString,
+    isNonEmptyString,
+    isPlainObject,
     isUndefined,
 } from '../../../kixx/assertions/mod.js';
+import { OperationalError } from '../../../kixx/errors/mod.js';
 
 /**
  * @typedef {import('../../../kixx/context/request-context.js').default} RequestContext
@@ -12,6 +16,7 @@ import {
 const BASE_TEMPLATE_PREFIX = 'base/';
 const PAGE_TEMPLATE_PREFIX = 'pages/';
 const PARTIALS_PREFIX = 'partials/';
+const PARTIALS_MANIFEST_FILENAME = 'partials.json';
 const DEFAULT_BINDING_NAME = 'HYPERVIEW_TEMPLATE_FILE_STORE';
 
 // Namespaced template keys are immutable: HyperviewService refuses any template
@@ -53,8 +58,17 @@ const MIN_CACHE_TTL_SECONDS = 30;
  * lower. The long TTL is configurable through
  * `config.env.HYPERVIEW_TEMPLATE_FILE_STORE.cacheTtl`.
  *
- * Note that `getPartials()` still performs an uncacheable `list()` before its
- * bulk read, because Cloudflare KV's list operation accepts no `cacheTtl`.
+ * A namespaced partial set is stored as one JSON manifest value at
+ * `{namespace}/partials.json`, mapping prefix-included logical filepaths (e.g.
+ * `partials/nav.html`) to source strings, so a namespaced `getPartials()`
+ * loads the complete set through one cacheable `get()` rather than an
+ * uncacheable `list()` plus a bulk read. `putPartials()` replaces the whole
+ * manifest value in one call; it never writes or reads the individual
+ * `{namespace}/partials/...` keys used before this format existed, and does
+ * not migrate or delete them. Without a namespace, `getPartials()` still
+ * performs an uncacheable `list()` before its bulk read, because Cloudflare
+ * KV's list operation accepts no `cacheTtl` and there is no single manifest
+ * key to address in the flat, unprefixed keyspace.
  *
  * @implements {import('../../../kixx/hyperview/template-file-store-interface.js').TemplateFileStoreInterface}
  */
@@ -124,26 +138,78 @@ export default class TemplateFileStore {
     }
 
     /**
-     * Writes (creates or updates) a partial template source file in the shared
-     * template KV store under the optional namespace.
+     * Replaces the complete partial template set for the required `namespace`,
+     * storing it as one JSON manifest value rather than one KV key per partial.
+     * A successful call overwrites any previously published manifest for
+     * `namespace` in a single KV `put()`; a failed call may leave the previous
+     * manifest, a partially written value, or nothing at all, and concurrent
+     * calls for the same `namespace` are not ordered by this method.
      * @param {RequestContext} context - Request context exposing the configured KV binding
-     * @param {string|null} [namespace] - Optional namespace used to prefix the KV key
-     * @param {string} filepath - Partial filename relative to `partials/`
-     * @param {string} source - Partial source text to store
-     * @returns {Promise<{filepath: string}>} Resolves with the logical filepath that was written
+     * @param {string} namespace - Required namespace (build id) that scopes the manifest key
+     * @param {import('../../../kixx/hyperview/template-file-store-interface.js').PartialInput[]} partials - Complete partial set to publish, with filepaths relative to `partials/`
+     * @returns {Promise<{filepath: string}[]>} Resolves with the logical, `partials/`-prefixed filepaths that were written, in submitted order
+     * @throws {AssertionError} When namespace is empty or invalid, partials is not an array, or an entry's filepath or source is invalid
+     * @throws {OperationalError} When the KV write fails
      */
-    async putPartial(context, namespace, filepath, source) {
-        return await this.#putFile(context, namespace, PARTIALS_PREFIX, filepath, source);
+    async putPartials(context, namespace, partials) {
+        const safeNamespace = this.#resolveNamespace(namespace);
+        assertNonEmptyString(safeNamespace, 'TemplateFileStore putPartials requires a non-empty namespace');
+        assertArray(partials, 'TemplateFileStore putPartials requires an array of partials');
+
+        const manifest = {};
+        const refs = [];
+
+        for (const { filepath, source } of partials) {
+            assertNonEmptyString(filepath, 'TemplateFileStore putPartials requires a filepath for every entry');
+            assertNonEmptyString(source, 'TemplateFileStore putPartials requires source text for every entry');
+            // Reject path traversal so a client cannot escape its prefix or the namespace.
+            assert(
+                !filepath.split('/').includes('..'),
+                'TemplateFileStore putPartials filepath must not contain ".." segments',
+            );
+
+            const logicalKey = `${ PARTIALS_PREFIX }${ filepath.replace(/^\//, '') }`;
+            manifest[logicalKey] = source;
+            refs.push({ filepath: logicalKey });
+        }
+
+        const manifestKey = this.#manifestKey(safeNamespace);
+        const kvStore = this.#getKVStore(context);
+        this.#logger.debug('putPartials() writing manifest', { key: manifestKey, count: refs.length });
+
+        try {
+            await kvStore.put(manifestKey, JSON.stringify(manifest));
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to write partial manifest "${ manifestKey }"`,
+                { cause },
+            );
+        }
+
+        return refs;
     }
 
     /**
-     * Retrieves all available partial templates from the shared template KV store.
+     * Retrieves all available partial templates from the shared template KV
+     * store. With a non-empty `namespace`, loads the complete set through one
+     * cacheable manifest `get()`; a namespace that was never published by
+     * `putPartials()` is an invariant failure, and an explicitly published
+     * empty set resolves to `[]`. Without a namespace, falls back to the flat,
+     * unprefixed `list()` plus bulk-read behavior.
      * @param {RequestContext} context - Request context exposing the configured KV binding
-     * @param {string|null} [namespace] - Optional namespace used to prefix the KV listing
-     * @returns {Promise<{filepath: string, source: string}[]>} Resolves to existing partial source files with logical filepaths in KV listing order
+     * @param {string|null} [namespace] - Optional namespace used to select the manifest or the flat listing
+     * @returns {Promise<{filepath: string, source: string}[]>} Resolves to existing partial source files with logical filepaths
+     * @throws {AssertionError} When a non-empty namespace's manifest is missing or structurally invalid
+     * @throws {OperationalError} When the KV read fails
      */
     async getPartials(context, namespace) {
-        return await this.#loadPrefixedFiles(context, namespace, PARTIALS_PREFIX);
+        const safeNamespace = this.#resolveNamespace(namespace);
+
+        if (!safeNamespace) {
+            return await this.#loadPrefixedFiles(context, namespace, PARTIALS_PREFIX);
+        }
+
+        return await this.#loadPartialsManifest(context, safeNamespace);
     }
 
     async #getFile(context, namespace, barePrefix, filepath) {
@@ -151,7 +217,16 @@ export default class TemplateFileStore {
         const cacheTtl = this.#resolveCacheTtl(context, namespace);
         this.#logger.debug('getFile() loading key', { key: kvKey, cacheTtl });
         const kvStore = this.#getKVStore(context);
-        const source = await kvStore.get(kvKey, { type: 'text', cacheTtl }) ?? null;
+
+        let source;
+        try {
+            source = await kvStore.get(kvKey, { type: 'text', cacheTtl }) ?? null;
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to read KV key "${ kvKey }"`,
+                { cause },
+            );
+        }
 
         if (source !== null) {
             return { filepath: logicalKey, source };
@@ -172,7 +247,15 @@ export default class TemplateFileStore {
         const { logicalKey, kvKey } = this.#resolveKey(namespace, barePrefix, filepath);
         this.#logger.debug('putFile() writing key', { key: kvKey });
         const kvStore = this.#getKVStore(context);
-        await kvStore.put(kvKey, source);
+
+        try {
+            await kvStore.put(kvKey, source);
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to write KV key "${ kvKey }"`,
+                { cause },
+            );
+        }
 
         return { filepath: logicalKey };
     }
@@ -291,4 +374,81 @@ export default class TemplateFileStore {
 
         return files;
     }
+
+    #manifestKey(namespace) {
+        return `${ namespace }/${ PARTIALS_MANIFEST_FILENAME }`;
+    }
+
+    async #loadPartialsManifest(context, namespace) {
+        const manifestKey = this.#manifestKey(namespace);
+        const cacheTtl = this.#resolveCacheTtl(context, namespace);
+        const kvStore = this.#getKVStore(context);
+        this.#logger.debug('getPartials() loading manifest', { key: manifestKey, cacheTtl });
+
+        let manifest;
+        try {
+            manifest = await kvStore.get(manifestKey, { type: 'json', cacheTtl });
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to read partial manifest "${ manifestKey }"`,
+                { cause },
+            );
+        }
+
+        // A namespace is expected to have been staged by putPartials() before it
+        // is ever read; a missing manifest means that never happened, which is an
+        // invariant failure rather than "no partials published yet".
+        assert(
+            manifest !== null,
+            `TemplateFileStore found no published partial manifest for namespace "${ namespace }"`,
+        );
+
+        return this.#parsePartialsManifest(manifest, manifestKey);
+    }
+
+    /**
+     * Validates manifest structure without normalizing it: keys and values are
+     * trusted verbatim from callers of putPartials(), so any deviation here
+     * indicates the manifest was corrupted or written outside this contract.
+     */
+    #parsePartialsManifest(manifest, manifestKey) {
+        assert(
+            isPlainObject(manifest),
+            `TemplateFileStore partial manifest "${ manifestKey }" must be a JSON object`,
+        );
+
+        const files = [];
+
+        for (const filepath of Object.keys(manifest)) {
+            const source = manifest[filepath];
+            assert(
+                isValidManifestKey(filepath),
+                `TemplateFileStore partial manifest "${ manifestKey }" has an invalid key "${ filepath }"`,
+            );
+            assert(
+                isNonEmptyString(source),
+                `TemplateFileStore partial manifest "${ manifestKey }" has an invalid source for "${ filepath }"`,
+            );
+            files.push({ filepath, source });
+        }
+
+        return files;
+    }
+}
+
+/**
+ * A valid manifest key is a canonical, lower-case logical filepath beginning
+ * with the `partials/` prefix, with no empty or traversal path segments.
+ */
+function isValidManifestKey(key) {
+    if (!isNonEmptyString(key) || key !== key.toLowerCase() || !key.startsWith(PARTIALS_PREFIX)) {
+        return false;
+    }
+
+    const remainder = key.slice(PARTIALS_PREFIX.length);
+    if (!remainder) {
+        return false;
+    }
+
+    return remainder.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
 }

--- a/src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js
+++ b/src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js
@@ -1,4 +1,9 @@
-import { assert, assertNonEmptyString } from '../../../kixx/assertions/mod.js';
+import {
+    AssertionError,
+    assert,
+    assertNonEmptyString,
+    isUndefined,
+} from '../../../kixx/assertions/mod.js';
 
 /**
  * @typedef {import('../../../kixx/context/request-context.js').default} RequestContext
@@ -8,6 +13,21 @@ const BASE_TEMPLATE_PREFIX = 'base/';
 const PAGE_TEMPLATE_PREFIX = 'pages/';
 const PARTIALS_PREFIX = 'partials/';
 const DEFAULT_BINDING_NAME = 'HYPERVIEW_TEMPLATE_FILE_STORE';
+
+// Namespaced template keys are immutable: HyperviewService refuses any template
+// write whose target build id matches the live one, so a deploy always writes a
+// *different* set of keys. A stale read is therefore impossible and the TTL can
+// be long enough that a build's templates stay warm between deploys.
+const DEFAULT_CACHE_TTL_SECONDS = 86400;
+
+// Without a namespace, reads fall to the flat keyspace, where nothing stops a
+// key from being overwritten in place — the immutability argument above does not
+// hold. Cap the TTL there at the same order as page data so a flat-keyspace
+// deployment does not have to wait a day to see an edited template.
+const MAX_UNNAMESPACED_CACHE_TTL_SECONDS = 300;
+
+// Cloudflare KV rejects a cacheTtl below 30 seconds.
+const MIN_CACHE_TTL_SECONDS = 30;
 
 /**
  * Cloudflare KV-backed store for shared Hyperview templates.
@@ -24,6 +44,17 @@ const DEFAULT_BINDING_NAME = 'HYPERVIEW_TEMPLATE_FILE_STORE';
  * Callers always work with logical filepaths; the namespace prefix is applied
  * and stripped internally, and keeping the read and write
  * namespaces consistent is the caller's responsibility.
+ *
+ * Reads pass an explicit `cacheTtl` so template keys stay warm in the network
+ * location they were read from for far longer than Cloudflare's 60 second
+ * default, which is what keeps cold-key latency off the page render path. A
+ * namespaced key is immutable for the life of its build, so the TTL there is
+ * long; an un-namespaced key can be overwritten in place and is capped much
+ * lower. The long TTL is configurable through
+ * `config.env.HYPERVIEW_TEMPLATE_FILE_STORE.cacheTtl`.
+ *
+ * Note that `getPartials()` still performs an uncacheable `list()` before its
+ * bulk read, because Cloudflare KV's list operation accepts no `cacheTtl`.
  *
  * @implements {import('../../../kixx/hyperview/template-file-store-interface.js').TemplateFileStoreInterface}
  */
@@ -117,9 +148,10 @@ export default class TemplateFileStore {
 
     async #getFile(context, namespace, barePrefix, filepath) {
         const { logicalKey, kvKey } = this.#resolveKey(namespace, barePrefix, filepath);
-        this.#logger.debug('getFile() loading key', { key: kvKey });
+        const cacheTtl = this.#resolveCacheTtl(context, namespace);
+        this.#logger.debug('getFile() loading key', { key: kvKey, cacheTtl });
         const kvStore = this.#getKVStore(context);
-        const source = await kvStore.get(kvKey, { type: 'text' }) ?? null;
+        const source = await kvStore.get(kvKey, { type: 'text', cacheTtl }) ?? null;
 
         if (source !== null) {
             return { filepath: logicalKey, source };
@@ -182,6 +214,43 @@ export default class TemplateFileStore {
         return namespace;
     }
 
+    /**
+     * Resolves the KV read cache TTL in seconds for a namespace. Namespaced keys
+     * get the configured (long) TTL because a build never rewrites its own
+     * templates; un-namespaced keys are capped because they can be overwritten in
+     * place.
+     * @param {RequestContext} context - Request context carrying the store config
+     * @param {string|null} [namespace] - Optional namespace supplied by the caller
+     * @returns {number} Cache TTL in seconds
+     * @throws {AssertionError} When a configured cacheTtl is not an integer of at least 30
+     */
+    #resolveCacheTtl(context, namespace) {
+        const { config } = context;
+        const { cacheTtl } = config?.env?.HYPERVIEW_TEMPLATE_FILE_STORE ?? {};
+
+        let ttl = DEFAULT_CACHE_TTL_SECONDS;
+
+        if (!isUndefined(cacheTtl) && cacheTtl !== null) {
+            // A misconfigured TTL is a source-config bug, not user input. Fail
+            // loudly here rather than letting Cloudflare reject the read
+            // mid-request.
+            if (!Number.isInteger(cacheTtl) || cacheTtl < MIN_CACHE_TTL_SECONDS) {
+                throw new AssertionError(
+                    `TemplateFileStore "cacheTtl" must be an integer of at least ${ MIN_CACHE_TTL_SECONDS } seconds`,
+                );
+            }
+            ttl = cacheTtl;
+        }
+
+        // Clamp rather than substitute, so a deployment which configures a TTL
+        // shorter than the flat-keyspace cap still gets the shorter value.
+        if (!this.#resolveNamespace(namespace)) {
+            return Math.min(ttl, MAX_UNNAMESPACED_CACHE_TTL_SECONDS);
+        }
+
+        return ttl;
+    }
+
     #getKVStore(context) {
         const { config, env } = context;
         let { bindingName } = config?.env?.HYPERVIEW_TEMPLATE_FILE_STORE ?? {};
@@ -197,6 +266,9 @@ export default class TemplateFileStore {
         const prefix = safeNamespace ? `${safeNamespace}/${barePrefix}` : barePrefix;
         this.#logger.debug('load prefixed files', { prefix });
 
+        // KV list() accepts no cacheTtl, so this call reaches the central store on
+        // every isolate that has not already loaded partials. Only the bulk read
+        // below benefits from the cache TTL.
         const { keys } = await kvStore.list({ prefix });
         const kvFilepaths = keys.map((key) => key.name);
 
@@ -204,7 +276,8 @@ export default class TemplateFileStore {
             return [];
         }
 
-        const resultMap = await kvStore.get(kvFilepaths, { type: 'text' });
+        const cacheTtl = this.#resolveCacheTtl(context, namespace);
+        const resultMap = await kvStore.get(kvFilepaths, { type: 'text', cacheTtl });
         const files = [];
 
         for (const kvFilepath of kvFilepaths) {

--- a/src/plugins/node-hyperview-template-file-store/lib/template-file-store.js
+++ b/src/plugins/node-hyperview-template-file-store/lib/template-file-store.js
@@ -3,8 +3,10 @@ import fsp from 'node:fs/promises';
 
 import {
     assert,
+    assertArray,
     assertNonEmptyString,
 } from '../../../kixx/assertions/mod.js';
+import { OperationalError } from '../../../kixx/errors/mod.js';
 
 const BASE_TEMPLATE_PREFIX = 'base/';
 const PAGE_TEMPLATE_PREFIX = 'pages/';
@@ -105,27 +107,90 @@ export default class TemplateFileStore {
     }
 
     /**
-     * Writes (creates or overwrites) a partial template source file in the shared
-     * template directory under the optional namespace.
+     * Replaces the complete partial template set for the required `namespace`.
+     * Removes the namespace's existing `partials/` directory, if any, then
+     * recreates it and writes the submitted set from scratch, so a file
+     * previously published under `namespace` but omitted from a later
+     * successful batch no longer exists afterward. A failed batch may leave the
+     * directory removed, partially written, or unchanged, and concurrent calls
+     * for the same `namespace` are not ordered by this method.
      * @param {Object} _context - Request or execution context accepted by the shared template file store interface
-     * @param {string|null} [namespace] - Optional namespace used to prefix the filesystem path
-     * @param {string} filepath - Partial filename relative to `partials/`
-     * @param {string} source - Partial source text to store
-     * @returns {Promise<{filepath: string}>} Resolves with the logical filepath that was written
+     * @param {string} namespace - Required namespace (build id) whose `partials/` directory is replaced
+     * @param {import('../../../kixx/hyperview/template-file-store-interface.js').PartialInput[]} partials - Complete partial set to publish, with filepaths relative to `partials/`
+     * @returns {Promise<{filepath: string}[]>} Resolves with the logical, `partials/`-prefixed filepaths that were written, in submitted order
+     * @throws {AssertionError} When namespace is empty or invalid, partials is not an array, or an entry's filepath or source is invalid
+     * @throws {OperationalError} When an unexpected filesystem failure occurs
      */
-    async putPartial(_context, namespace, filepath, source) {
-        return await this.#putFile(namespace, PARTIALS_PREFIX, filepath, source);
+    async putPartials(_context, namespace, partials) {
+        const safeNamespace = this.#resolveNamespace(namespace);
+        assertNonEmptyString(safeNamespace, 'TemplateFileStore putPartials requires a non-empty namespace');
+        assertArray(partials, 'TemplateFileStore putPartials requires an array of partials');
+
+        const entries = partials.map(({ filepath, source }) => {
+            const safeFilepath = this.#resolveFilepath(filepath, 'write');
+            assertNonEmptyString(source, 'TemplateFileStore write requires source text');
+            const { logicalKey, fsPath } = this.#resolveKey(safeNamespace, PARTIALS_PREFIX, safeFilepath);
+            return { logicalKey, fsPath, source };
+        });
+
+        const prefixDir = path.join(this.#directory, safeNamespace, PARTIALS_PREFIX);
+        this.#logger.debug('putPartials() replacing directory', { path: prefixDir, count: entries.length });
+
+        try {
+            await fsp.rm(prefixDir, { recursive: true, force: true });
+            await fsp.mkdir(prefixDir, { recursive: true });
+            for (const { fsPath, source } of entries) {
+                await fsp.mkdir(path.dirname(fsPath), { recursive: true });
+                await fsp.writeFile(fsPath, source, 'utf8');
+            }
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to replace partials directory "${ prefixDir }"`,
+                { cause },
+            );
+        }
+
+        return entries.map(({ logicalKey }) => ({ filepath: logicalKey }));
     }
 
     /**
      * Retrieves all available partial templates from the shared template
-     * directory, walking the `partials/` tree recursively.
+     * directory, walking the `partials/` tree recursively. With a non-empty
+     * `namespace`, requires that `putPartials()` has already published a set
+     * for that namespace; a missing directory is an invariant failure and an
+     * empty directory resolves to `[]`. Without a namespace, a missing
+     * directory resolves to `[]`.
      * @param {Object} _context - Request or execution context accepted by the shared template file store interface
      * @param {string|null} [namespace] - Optional namespace used to prefix the partials directory
      * @returns {Promise<{filepath: string, source: string}[]>} Resolves to existing partial source files with logical filepaths in directory walk order
+     * @throws {AssertionError} When a non-empty namespace's partials directory does not exist
+     * @throws {OperationalError} When an unexpected filesystem failure occurs
      */
     async getPartials(_context, namespace) {
-        return await this.#loadPrefixedFiles(namespace, PARTIALS_PREFIX);
+        const safeNamespace = this.#resolveNamespace(namespace);
+        const namespaceRoot = path.join(this.#directory, safeNamespace);
+        const prefixDir = path.join(namespaceRoot, PARTIALS_PREFIX);
+        this.#logger.debug('getPartials() loading directory', { path: prefixDir });
+
+        const absolutePaths = await this.#walkPartialsFiles(prefixDir, safeNamespace, true);
+        const files = [];
+
+        for (const absolutePath of absolutePaths) {
+            let source;
+            try {
+                source = await fsp.readFile(absolutePath, 'utf8');
+            } catch (cause) {
+                throw new OperationalError(
+                    `TemplateFileStore failed to read partial file "${ absolutePath }"`,
+                    { cause },
+                );
+            }
+            // Normalize OS separators back to the logical '/' delimiter.
+            const filepath = path.relative(namespaceRoot, absolutePath).split(path.sep).join('/');
+            files.push({ filepath, source });
+        }
+
+        return files;
     }
 
     async #getFile(namespace, barePrefix, filepath) {
@@ -141,7 +206,10 @@ export default class TemplateFileStore {
             if (cause.code === 'ENOENT') {
                 return null;
             }
-            throw cause;
+            throw new OperationalError(
+                `TemplateFileStore failed to read template file "${ fsPath }"`,
+                { cause },
+            );
         }
 
         return { filepath: logicalKey, source };
@@ -154,10 +222,17 @@ export default class TemplateFileStore {
         const { logicalKey, fsPath } = this.#resolveKey(namespace, barePrefix, safeFilepath);
         this.#logger.debug('putFile() writing path', { path: fsPath });
 
-        // Nested page templates and partials live several directories deep; ensure
-        // the parent tree exists before writing the file.
-        await fsp.mkdir(path.dirname(fsPath), { recursive: true });
-        await fsp.writeFile(fsPath, source, 'utf8');
+        try {
+            // Nested page templates and partials live several directories deep;
+            // ensure the parent tree exists before writing the file.
+            await fsp.mkdir(path.dirname(fsPath), { recursive: true });
+            await fsp.writeFile(fsPath, source, 'utf8');
+        } catch (cause) {
+            throw new OperationalError(
+                `TemplateFileStore failed to write template file "${ fsPath }"`,
+                { cause },
+            );
+        }
 
         return { filepath: logicalKey };
     }
@@ -214,50 +289,42 @@ export default class TemplateFileStore {
         return namespace;
     }
 
-    async #loadPrefixedFiles(namespace, barePrefix) {
-        const safeNamespace = this.#resolveNamespace(namespace);
-        // The namespace root is what logical filepaths are made relative to, so a
-        // returned filepath keeps the bare prefix (e.g. `partials/nav.html`) but
-        // never the namespace.
-        const namespaceRoot = path.join(this.#directory, safeNamespace);
-        const prefixDir = path.join(namespaceRoot, barePrefix);
-        this.#logger.debug('load prefixed files', { path: prefixDir });
-
-        const absolutePaths = await this.#walkFiles(prefixDir);
-        const files = [];
-
-        for (const absolutePath of absolutePaths) {
-            const source = await fsp.readFile(absolutePath, 'utf8');
-            // Normalize OS separators back to the logical '/' delimiter.
-            const filepath = path.relative(namespaceRoot, absolutePath).split(path.sep).join('/');
-            files.push({ filepath, source });
-        }
-
-        return files;
-    }
-
     /**
-     * Recursively collects absolute file paths under a directory. A missing
-     * directory yields an empty list, mirroring "no files present".
+     * Recursively collects absolute file paths under the partials directory.
+     * A missing directory is only an invariant failure at the top level of a
+     * namespaced read, where it means putPartials() was never called for that
+     * namespace; a missing top-level flat directory, or a missing nested
+     * directory encountered mid-walk, yields an empty list.
      * @param {string} dir - Directory to walk
+     * @param {string} safeNamespace - Resolved namespace, or `''` for the flat namespace
+     * @param {boolean} isTopLevel - Whether `dir` is the partials directory itself, not a nested directory
      * @returns {Promise<string[]>} Absolute paths of every regular file found
+     * @throws {AssertionError} When the top-level directory of a namespaced read is missing
+     * @throws {OperationalError} When an unexpected filesystem failure occurs
      */
-    async #walkFiles(dir) {
+    async #walkPartialsFiles(dir, safeNamespace, isTopLevel) {
         let entries;
         try {
             entries = await fsp.readdir(dir, { withFileTypes: true });
         } catch (cause) {
             if (cause.code === 'ENOENT') {
+                assert(
+                    !(isTopLevel && safeNamespace),
+                    `TemplateFileStore found no published partials directory for namespace "${ safeNamespace }"`,
+                );
                 return [];
             }
-            throw cause;
+            throw new OperationalError(
+                `TemplateFileStore failed to read partials directory "${ dir }"`,
+                { cause },
+            );
         }
 
         const files = [];
         for (const entry of entries) {
             const fullPath = path.join(dir, entry.name);
             if (entry.isDirectory()) {
-                const nested = await this.#walkFiles(fullPath);
+                const nested = await this.#walkPartialsFiles(fullPath, safeNamespace, false);
                 files.push(...nested);
             } else if (entry.isFile()) {
                 files.push(fullPath);

--- a/src/routes/publishing-api-v1.js
+++ b/src/routes/publishing-api-v1.js
@@ -32,7 +32,9 @@ export default [
         ],
     },
     {
-        pattern: '/templates/partials/*filepath',
+        // Exact collection route: no wildcard segment, so it cannot be shadowed
+        // by (and cannot shadow) the base/page template wildcard routes above.
+        pattern: '/templates/partials{/}',
         name: 'partial-templates',
         targets: [
             {
@@ -40,7 +42,7 @@ export default [
                 methods: [ 'PUT' ],
                 requestHandlers: [
                     Permissions.requireTemplatePermission,
-                    PublishingAPI.putPartialTemplate,
+                    PublishingAPI.putPartials,
                 ],
             },
         ],

--- a/test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js
+++ b/test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js
@@ -1,0 +1,140 @@
+import { describe } from 'kixx-test';
+import { assert, assertEqual } from 'kixx-assert';
+
+import PutPartialsForm from '../../../../../../src/app/presentation/forms/templates/put-partials-form.js';
+
+
+describe('PutPartialsForm', ({ it }) => {
+    it('accepts an empty partial set', () => {
+        const form = PutPartialsForm.fromJsonApi({ attributes: { partials: [] } });
+
+        form.validate();
+
+        assertEqual(0, form.toJSON().partials.length);
+    });
+
+    it('preserves source text exactly, without trimming', () => {
+        const form = PutPartialsForm.fromJsonApi({
+            attributes: {
+                partials: [ { filepath: 'nav.html', source: '  <nav>\t</nav>  \n' } ],
+            },
+        });
+
+        form.validate();
+
+        assertEqual('  <nav>\t</nav>  \n', form.toJSON().partials[0].source);
+    });
+
+    it('folds a safe filepath to lower case without trimming it', () => {
+        const form = PutPartialsForm.fromJsonApi({
+            attributes: {
+                partials: [ { filepath: 'Shared/Nav.HTML', source: '<nav/>' } ],
+            },
+        });
+
+        form.validate();
+
+        assertEqual('shared/nav.html', form.toJSON().partials[0].filepath);
+    });
+
+    it('ignores unknown attributes and unknown entry properties', () => {
+        const form = PutPartialsForm.fromJsonApi({
+            attributes: {
+                partials: [ { filepath: 'nav.html', source: '<nav/>', extra: 'ignored' } ],
+                unknownAttribute: 'ignored',
+            },
+        });
+
+        form.validate();
+        const values = form.toJSON();
+
+        assertEqual(1, values.partials.length);
+        assertEqual('nav.html', values.partials[0].filepath);
+        assertEqual('<nav/>', values.partials[0].source);
+        assertEqual(undefined, values.partials[0].extra);
+    });
+
+    it('rejects a non-array partials value', () => {
+        const form = PutPartialsForm.fromJsonApi({ attributes: { partials: 'nope' } });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials' ]);
+    });
+
+    it('rejects a missing filepath', () => {
+        const form = new PutPartialsForm({ partials: [ { source: '<nav/>' } ] });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials[0].filepath' ]);
+    });
+
+    it('rejects a missing source', () => {
+        const form = new PutPartialsForm({ partials: [ { filepath: 'nav.html' } ] });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials[0].source' ]);
+    });
+
+    it('rejects traversal, leading, trailing, and doubled slash filepaths', () => {
+        const badFilepaths = [ '../nav.html', '/nav.html', 'nav.html/', 'nav//footer.html' ];
+
+        for (const filepath of badFilepaths) {
+            const form = new PutPartialsForm({ partials: [ { filepath, source: '<nav/>' } ] });
+            const caught = catchError(() => form.validate());
+
+            assertValidationSources(caught, [ 'partials[0].filepath' ]);
+        }
+    });
+
+    it('rejects a filepath with disallowed characters', () => {
+        const form = new PutPartialsForm({ partials: [ { filepath: 'nav file.html', source: '<nav/>' } ] });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials[0].filepath' ]);
+    });
+
+    it('reports every applicable field error across the whole batch, not just the first', () => {
+        const form = new PutPartialsForm({
+            partials: [
+                { filepath: '', source: '<nav/>' },
+                { filepath: 'footer.html', source: '' },
+            ],
+        });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials[0].filepath', 'partials[1].source' ]);
+    });
+
+    it('rejects duplicate filepaths that collide only after case-folding normalization', () => {
+        const form = new PutPartialsForm({
+            partials: [
+                { filepath: 'Nav.html', source: '<nav/>' },
+                { filepath: 'nav.html', source: '<nav-2/>' },
+            ],
+        });
+
+        const caught = catchError(() => form.validate());
+
+        assertValidationSources(caught, [ 'partials[1].filepath' ]);
+    });
+});
+
+function assertValidationSources(error, expectedSources) {
+    assert(error, 'expected a ValidationError');
+    assertEqual('ValidationError', error.name);
+    assertEqual(expectedSources.join(','), error.errors.map(({ source }) => source).join(','));
+}
+
+function catchError(fn) {
+    try {
+        fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}

--- a/test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js
+++ b/test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js
@@ -1,0 +1,413 @@
+import { describe } from 'kixx-test';
+import { assert, assertEqual, assertMatches } from 'kixx-assert';
+
+import {
+    BUILD_ID_HEADER,
+    JSON_API_CONTENT_TYPE,
+} from '../../../../../../src/app/presentation/lib/json-api.js';
+import { putPartials } from '../../../../../../src/app/presentation/request-handlers/publishing-api/put-partials.js';
+
+
+const CURRENT_BUILD_ID = 'build-current';
+const TARGET_BUILD_ID = 'build-next';
+
+// Mirrors MAX_PARTIALS_BYTES in the handler.
+const MAX_PARTIALS_BYTES = 25 * 1024 * 1024;
+
+
+describe('putPartials publishing API handler', ({ it }) => {
+
+    it('writes the normalized batch through HyperviewService.putPartials', async () => {
+        const service = makeHyperviewService();
+        const response = makeResponse();
+
+        await putPartials(
+            makeContext({ service }),
+            makeRequest({
+                partials: [
+                    { filepath: 'nav.html', source: '<nav/>' },
+                    { filepath: 'footer.html', source: '<footer/>' },
+                ],
+            }),
+            response,
+        );
+
+        assertEqual(1, service.writes.length);
+        assertEqual(TARGET_BUILD_ID, service.writes[0].buildId);
+        assertEqual(2, service.writes[0].partials.length);
+        assertEqual('nav.html', service.writes[0].partials[0].filepath);
+        assertEqual('<nav/>', service.writes[0].partials[0].source);
+    });
+
+    it('responds with a committed JSON API PartialTemplateSet resource', async () => {
+        const response = makeResponse();
+
+        await putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ partials: [ { filepath: 'nav.html', source: '<nav/>' } ] }),
+            response,
+        );
+
+        assertEqual(200, response.status);
+        assertEqual(JSON_API_CONTENT_TYPE, response.options.contentType);
+        assertEqual('PartialTemplateSet', response.document.data.type);
+        assertEqual(`partials/${ TARGET_BUILD_ID }`, response.document.data.id);
+        assertEqual(TARGET_BUILD_ID, response.document.data.attributes.buildId);
+        assertEqual(1, response.document.data.attributes.partials.length);
+        assertEqual('partials/nav.html', response.document.data.attributes.partials[0].filepath);
+        assertEqual(undefined, response.document.data.attributes.partials[0].source);
+    });
+
+    it('returns the response object so route outbound middleware still runs', async () => {
+        const response = makeResponse();
+        const returned = await putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ partials: [] }),
+            response,
+        );
+
+        assertEqual(response, returned);
+    });
+
+    it('accepts and forwards a complete empty set', async () => {
+        const service = makeHyperviewService();
+        const response = makeResponse();
+
+        await putPartials(makeContext({ service }), makeRequest({ partials: [] }), response);
+
+        assertEqual(1, service.writes.length);
+        assertEqual(0, service.writes[0].partials.length);
+        assertEqual(0, response.document.data.attributes.partials.length);
+    });
+
+    it('accepts a matching data.id and echoes it back', async () => {
+        const response = makeResponse();
+
+        await putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ id: `partials/${ TARGET_BUILD_ID }`, partials: [] }),
+            response,
+        );
+
+        assertEqual(`partials/${ TARGET_BUILD_ID }`, response.document.data.id);
+    });
+
+    it('rejects a data.id that does not match partials/<buildId>', async () => {
+        const service = makeHyperviewService();
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service }),
+            makeRequest({ id: 'partials/some-other-build', partials: [] }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ConflictError', caught.name);
+        assertEqual('JsonApiResourceIdMismatch', caught.code);
+        assertEqual(0, service.writes.length);
+    });
+
+    it('rejects a resource type other than PartialTemplateSet', async () => {
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ type: 'Template', partials: [] }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ConflictError', caught.name);
+        assertEqual('JsonApiResourceTypeMismatch', caught.code);
+    });
+
+    it('rejects a media type other than application/vnd.api+json', async () => {
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ partials: [], contentType: 'application/json' }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('UnsupportedMediaTypeError', caught.name);
+        assertEqual(415, caught.httpStatusCode);
+    });
+
+    it('rejects a missing Content-Length with a 411 before touching the body', async () => {
+        let bodyAccessCount = 0;
+        const request = makeRequest({
+            partials: [],
+            omitContentLength: true,
+            onBodyAccess() {
+                bodyAccessCount += 1;
+            },
+        });
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            request,
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual(411, caught.httpStatusCode);
+        assertEqual('ContentLengthRequired', caught.code);
+        assertEqual(0, bodyAccessCount);
+    });
+
+    it('rejects a malformed Content-Length with a 400 before touching the body', async () => {
+        let bodyAccessCount = 0;
+        const request = makeRequest({
+            partials: [],
+            contentLength: 'twelve',
+            onBodyAccess() {
+                bodyAccessCount += 1;
+            },
+        });
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            request,
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual(400, caught.httpStatusCode);
+        assertEqual('ContentLengthInvalid', caught.code);
+        assertEqual(0, bodyAccessCount);
+    });
+
+    it('rejects a negative Content-Length as malformed', async () => {
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ partials: [], contentLength: '-5' }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual('ContentLengthInvalid', caught.code);
+    });
+
+    it('rejects a declared Content-Length above 25 MiB without touching the body', async () => {
+        let bodyAccessCount = 0;
+        const request = makeRequest({
+            partials: [],
+            contentLength: MAX_PARTIALS_BYTES + 1,
+            onBodyAccess() {
+                bodyAccessCount += 1;
+            },
+        });
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            request,
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('PayloadTooLargeError', caught.name);
+        assertEqual(413, caught.httpStatusCode);
+        assertEqual(0, bodyAccessCount);
+    });
+
+    it('rejects an oversized body whose Content-Length understated the actual bytes', async () => {
+        // The size cap is enforced against streamed bytes before JSON parsing, so
+        // the oversized body does not need to be well-formed JSON:API.
+        const oversizedBody = new Uint8Array(MAX_PARTIALS_BYTES + 1);
+        const request = makeRawRequest(oversizedBody, { contentLength: 10 });
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            request,
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('PayloadTooLargeError', caught.name);
+        assertEqual(413, caught.httpStatusCode);
+    });
+
+    it('rejects a malformed JSON body using the same contract as request.json()', async () => {
+        const request = makeRawRequest(new TextEncoder().encode('{ not valid json'));
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            request,
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertMatches('Invalid JSON in request body', caught.message);
+    });
+
+    it('rejects an invalid partial entry via the Form, without writing', async () => {
+        const service = makeHyperviewService();
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service }),
+            makeRequest({ partials: [ { filepath: '../escape.html', source: '<nav/>' } ] }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ValidationError', caught.name);
+        assertEqual(0, service.writes.length);
+    });
+
+    it('requires the build id header, which has no current-build fallback', async () => {
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service: makeHyperviewService() }),
+            makeRequest({ partials: [], buildId: null }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual('BuildIdRequired', caught.code);
+    });
+
+    it('refuses to write into the current build', async () => {
+        const service = makeHyperviewService();
+        const caught = await catchAsyncError(() => putPartials(
+            makeContext({ service }),
+            makeRequest({ partials: [], buildId: CURRENT_BUILD_ID }),
+            makeResponse(),
+        ));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ConflictError', caught.name);
+        assertEqual('CurrentBuildWriteConflict', caught.code);
+        assertEqual(0, service.writes.length);
+    });
+
+    it('allows staging partials before the site has any current build', async () => {
+        const service = makeHyperviewService();
+        const response = makeResponse();
+
+        await putPartials(
+            makeContext({ service, currentBuildId: null }),
+            makeRequest({ partials: [] }),
+            response,
+        );
+
+        assertEqual(200, response.status);
+        assertEqual(TARGET_BUILD_ID, service.writes[0].buildId);
+    });
+});
+
+function makeHyperviewService(onWrite) {
+    const service = { writes: [] };
+
+    service.putPartials = async (_context, buildId, partials) => {
+        service.writes.push({ buildId, partials });
+        if (onWrite) {
+            return onWrite();
+        }
+        return partials.map(({ filepath }) => ({ filepath: `partials/${ filepath }` }));
+    };
+
+    return service;
+}
+
+function makeContext(options) {
+    const { service, currentBuildId = CURRENT_BUILD_ID } = options ?? {};
+
+    return {
+        runtime: { build: currentBuildId ? { id: currentBuildId } : null },
+        getService(name) {
+            assertEqual('Hyperview', name);
+            return service;
+        },
+    };
+}
+
+function makeRequest(options) {
+    const {
+        id,
+        type = 'PartialTemplateSet',
+        partials,
+        contentType = JSON_API_CONTENT_TYPE,
+        buildId = TARGET_BUILD_ID,
+        contentLength,
+        omitContentLength = false,
+        onBodyAccess,
+    } = options ?? {};
+
+    const data = { type, attributes: { partials } };
+    if (id) {
+        data.id = id;
+    }
+
+    const bodyBytes = new TextEncoder().encode(JSON.stringify({ data }));
+
+    return makeRawRequest(bodyBytes, {
+        contentType,
+        buildId,
+        contentLength,
+        omitContentLength,
+        onBodyAccess,
+    });
+}
+
+function makeRawRequest(bodyBytes, options) {
+    const {
+        contentType = JSON_API_CONTENT_TYPE,
+        buildId = TARGET_BUILD_ID,
+        contentLength,
+        omitContentLength = false,
+        onBodyAccess,
+    } = options ?? {};
+
+    const headers = new Headers();
+    if (buildId) {
+        headers.set(BUILD_ID_HEADER, buildId);
+    }
+    if (!omitContentLength) {
+        const declared = typeof contentLength !== 'undefined' ? contentLength : bodyBytes.byteLength;
+        headers.set('content-length', String(declared));
+    }
+
+    let bodyStream = null;
+
+    return {
+        headers,
+        // Built lazily so a test can prove the handler rejected the request
+        // before it reached for the body stream at all.
+        get body() {
+            if (onBodyAccess) {
+                onBodyAccess();
+            }
+            bodyStream = bodyStream || makeBodyStream(bodyBytes);
+            return bodyStream;
+        },
+        getContentMediaType() {
+            return contentType;
+        },
+    };
+}
+
+function makeBodyStream(bytes) {
+    return new ReadableStream({
+        start(controller) {
+            if (bytes.byteLength > 0) {
+                controller.enqueue(bytes);
+            }
+            controller.close();
+        },
+    });
+}
+
+function makeResponse() {
+    return {
+        respondWithJSON(status, document, options) {
+            this.status = status;
+            this.document = document;
+            this.options = options;
+            return this;
+        },
+    };
+}
+
+async function catchAsyncError(fn) {
+    try {
+        await fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}

--- a/test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js
+++ b/test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js
@@ -8,7 +8,6 @@ import {
 import {
     putBaseTemplate,
     putPageTemplate,
-    putPartialTemplate,
 } from '../../../../../../src/app/presentation/request-handlers/publishing-api/put-template.js';
 
 
@@ -20,7 +19,6 @@ const TARGET_BUILD_ID = 'build-next';
 const HANDLERS = [
     { kind: 'base', handler: putBaseTemplate, method: 'putBaseTemplate' },
     { kind: 'page', handler: putPageTemplate, method: 'putPageTemplate' },
-    { kind: 'partial', handler: putPartialTemplate, method: 'putPartial' },
 ];
 
 
@@ -81,7 +79,7 @@ describe('putTemplate publishing API handlers', ({ describe, it }) => {
         const service = makeHyperviewService();
         const response = makeResponse();
 
-        await putPartialTemplate(
+        await putPageTemplate(
             makeContext({ service }),
             makeRequest({ filepath: [ 'blog', 'byline.html' ], source: 'source' }),
             response,

--- a/test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js
@@ -1,0 +1,188 @@
+import { describe } from 'kixx-test';
+import { assert, assertEqual, assertMatches } from 'kixx-assert';
+
+import { putPartials } from '../../../../../src/app/transaction-scripts/publishing/put-partials.js';
+
+
+const CURRENT_BUILD_ID = 'build-current';
+const TARGET_BUILD_ID = 'build-next';
+
+
+describe('putPartials Transaction Script', ({ it }) => {
+    it('requires a target build id before accessing Hyperview', async () => {
+        const harness = makeHarness();
+        const caught = await catchAsyncError(() => putPartials(harness.context, {
+            partials: [ { filepath: 'nav.html', source: '<nav/>' } ],
+        }));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('BadRequestError', caught.name);
+        assertEqual('BuildIdRequired', caught.code);
+        assertEqual(400, caught.httpStatusCode);
+        assertEqual(0, harness.calls.serviceAccess);
+        assertEqual(0, harness.calls.putPartials.length);
+    });
+
+    it('rejects invalid and reserved target Build IDs before accessing Hyperview', async () => {
+        for (const [ buildId, code ] of [ [ 'build/child', 'InvalidBuildId' ], [ 'dev', 'ReservedBuildId' ] ]) {
+            const harness = makeHarness();
+            const caught = await catchAsyncError(() => putPartials(harness.context, {
+                buildId,
+                partials: [],
+            }));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('BadRequestError', caught.name);
+            assertEqual(code, caught.code);
+            assertEqual(0, harness.calls.serviceAccess);
+            assertEqual(0, harness.calls.putPartials.length);
+        }
+    });
+
+    it('refuses to write into the current build before accessing Hyperview', async () => {
+        const harness = makeHarness();
+        const caught = await catchAsyncError(() => putPartials(harness.context, {
+            buildId: CURRENT_BUILD_ID,
+            partials: [],
+        }));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('ConflictError', caught.name);
+        assertEqual('CurrentBuildWriteConflict', caught.code);
+        assertEqual(409, caught.httpStatusCode);
+        assertEqual(0, harness.calls.serviceAccess);
+        assertEqual(0, harness.calls.putPartials.length);
+    });
+
+    it('delegates once to HyperviewService.putPartials and returns its result', async () => {
+        const harness = makeHarness();
+        const partials = [
+            { filepath: 'nav.html', source: '<nav/>' },
+            { filepath: 'footer.html', source: '<footer/>' },
+        ];
+
+        const result = await putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials,
+        });
+
+        assertEqual(1, harness.calls.serviceAccess);
+        assertEqual('Hyperview', harness.calls.serviceNames[0]);
+        assertEqual(1, harness.calls.putPartials.length);
+        assertEqual(harness.context, harness.calls.putPartials[0].context);
+        assertEqual(TARGET_BUILD_ID, harness.calls.putPartials[0].buildId);
+        assertEqual(partials, harness.calls.putPartials[0].partials);
+        assertEqual(2, result.length);
+        assertEqual('partials/nav.html', result[0].filepath);
+        assertEqual('partials/footer.html', result[1].filepath);
+    });
+
+    it('accepts and forwards an empty partial set', async () => {
+        const harness = makeHarness();
+
+        const result = await putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials: [],
+        });
+
+        assertEqual(1, harness.calls.putPartials.length);
+        assertEqual(0, harness.calls.putPartials[0].partials.length);
+        assertEqual(0, result.length);
+    });
+
+    it('allows the first deployment to stage partials without a current build', async () => {
+        const harness = makeHarness({ currentBuildId: null });
+
+        await putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials: [],
+        });
+
+        assertEqual(1, harness.calls.putPartials.length);
+    });
+
+    it('translates an expected store failure into an OperationalError, preserving cause', async () => {
+        const cause = Object.assign(new Error('template file store unavailable'), { expected: true });
+        const harness = makeHarness({ writeError: cause });
+
+        const caught = await catchAsyncError(() => putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials: [],
+        }));
+
+        assert(caught, 'expected an error to be thrown');
+        assertEqual('OperationalError', caught.name);
+        assertEqual(cause, caught.cause);
+        assertMatches('Failed to publish the partial template set', caught.message);
+    });
+
+    it('propagates an AssertionError from the store unchanged', async () => {
+        const cause = new Error('canonical filepath assertion failed');
+        cause.name = 'AssertionError';
+        const harness = makeHarness({ writeError: cause });
+
+        const caught = await catchAsyncError(() => putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials: [],
+        }));
+
+        assertEqual(cause, caught);
+    });
+
+    it('propagates a native programmer error from the store unchanged', async () => {
+        const cause = new TypeError('cannot read property of undefined');
+        const harness = makeHarness({ writeError: cause });
+
+        const caught = await catchAsyncError(() => putPartials(harness.context, {
+            buildId: TARGET_BUILD_ID,
+            partials: [],
+        }));
+
+        assertEqual(cause, caught);
+    });
+});
+
+function makeHarness(options) {
+    const {
+        currentBuildId = CURRENT_BUILD_ID,
+        writeError = null,
+    } = options ?? {};
+
+    const calls = {
+        putPartials: [],
+        serviceAccess: 0,
+        serviceNames: [],
+    };
+
+    const service = {
+        async putPartials(writeContext, buildId, partials) {
+            calls.putPartials.push({ context: writeContext, buildId, partials });
+            if (writeError) {
+                throw writeError;
+            }
+            return partials.map(({ filepath }) => ({ filepath: `partials/${ filepath }` }));
+        },
+    };
+
+    const context = {
+        runtime: {
+            build: currentBuildId ? { id: currentBuildId } : null,
+        },
+        getService(name) {
+            calls.serviceAccess += 1;
+            calls.serviceNames.push(name);
+            return service;
+        },
+    };
+
+    return { context, calls };
+}
+
+async function catchAsyncError(fn) {
+    try {
+        await fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}

--- a/test/unit-tests/app/transaction-scripts/publishing/put-template.test.js
+++ b/test/unit-tests/app/transaction-scripts/publishing/put-template.test.js
@@ -12,7 +12,7 @@ describe('putTemplate Transaction Script', ({ it }) => {
     it('rejects an unsupported template kind before accessing Hyperview', async () => {
         const harness = makeHarness();
         const caught = await catchAsyncError(() => putTemplate(harness.context, {
-            kind: 'layout',
+            kind: 'partial',
             filepath: 'website.html',
             source: '<html></html>',
             buildId: TARGET_BUILD_ID,
@@ -20,7 +20,7 @@ describe('putTemplate Transaction Script', ({ it }) => {
 
         assert(caught, 'expected an error to be thrown');
         assertEqual('AssertionError', caught.name);
-        assertMatches('putTemplate() kind must be base, page, or partial', caught.message);
+        assertMatches('putTemplate() kind must be base or page', caught.message);
         assertEqual(0, harness.calls.serviceAccess);
         assertEqual(0, getWriteCallCount(harness.calls));
     });
@@ -81,7 +81,7 @@ describe('putTemplate Transaction Script', ({ it }) => {
     it('refuses to write into the current build before accessing Hyperview', async () => {
         const harness = makeHarness();
         const caught = await catchAsyncError(() => putTemplate(harness.context, {
-            kind: 'partial',
+            kind: 'page',
             filepath: 'card.html',
             source: '<article></article>',
             buildId: CURRENT_BUILD_ID,
@@ -103,7 +103,6 @@ describe('putTemplate Transaction Script', ({ it }) => {
         const scenarios = [
             { kind: 'base', method: 'putBaseTemplate' },
             { kind: 'page', method: 'putPageTemplate' },
-            { kind: 'partial', method: 'putPartial' },
         ];
 
         for (const { kind, method } of scenarios) {
@@ -166,7 +165,6 @@ function makeHarness(options) {
     const calls = {
         putBaseTemplate: [],
         putPageTemplate: [],
-        putPartial: [],
         serviceAccess: 0,
         serviceNames: [],
     };
@@ -176,9 +174,6 @@ function makeHarness(options) {
         },
         async putPageTemplate(context, buildId, filepath, source) {
             return await write('page', 'putPageTemplate', context, buildId, filepath, source);
-        },
-        async putPartial(context, buildId, filepath, source) {
-            return await write('partial', 'putPartial', context, buildId, filepath, source);
         },
     };
     const context = {
@@ -210,8 +205,7 @@ function makeHarness(options) {
 
 function getWriteCallCount(calls) {
     return calls.putBaseTemplate.length
-        + calls.putPageTemplate.length
-        + calls.putPartial.length;
+        + calls.putPageTemplate.length;
 }
 
 async function catchAsyncError(fn) {

--- a/test/unit-tests/kixx/hyperview/hyperview-service.test.js
+++ b/test/unit-tests/kixx/hyperview/hyperview-service.test.js
@@ -496,6 +496,135 @@ describe('HyperviewService', ({ describe }) => {
         });
     });
 
+    describe('loadPartials caching', ({ it }) => {
+
+        // Resolves the store read only when the returned trigger is called, so a
+        // test can hold several loadPartials() calls in flight at once.
+        function makeDeferredPartialsStore() {
+            const stores = makeStores();
+            let reads = 0;
+            let release;
+            const gate = new Promise((resolve) => {
+                release = resolve;
+            });
+
+            stores.templateFileStore.getPartials = async () => {
+                reads += 1;
+                await gate;
+                return [ { filepath: 'partials/nav.html', source: 'Navigation' } ];
+            };
+
+            return {
+                stores,
+                release,
+                getReads() {
+                    return reads;
+                },
+            };
+        }
+
+        // getBaseTemplate() and getPageTemplate() both call loadPartials(), and the
+        // request handlers run them through Promise.all, so the in-flight load has
+        // to be shared or every cold render loads partials twice.
+        it('shares one in-flight load between concurrent callers', async () => {
+            const { stores, release, getReads } = makeDeferredPartialsStore();
+            const service = makeService(stores);
+            const context = makeContext();
+
+            const pending = Promise.all([
+                service.loadPartials(context, { useCache: true }),
+                service.loadPartials(context, { useCache: true }),
+            ]);
+
+            release();
+            const [ first, second ] = await pending;
+
+            assertEqual(1, getReads());
+            assert(first === second, 'expected both callers to resolve to the same map');
+        });
+
+        it('reuses the resolved load on a later call', async () => {
+            const { stores, release, getReads } = makeDeferredPartialsStore();
+            const service = makeService(stores);
+            const context = makeContext();
+
+            release();
+            const first = await service.loadPartials(context, { useCache: true });
+            const second = await service.loadPartials(context, { useCache: true });
+
+            assertEqual(1, getReads());
+            assert(first === second, 'expected the cached map to be returned');
+        });
+
+        it('does not share loads across build ids', async () => {
+            const { stores, release, getReads } = makeDeferredPartialsStore();
+            const service = makeService(stores);
+
+            release();
+            await service.loadPartials(makeContext('build-1'), { useCache: true });
+            await service.loadPartials(makeContext('build-2'), { useCache: true });
+
+            assertEqual(2, getReads());
+        });
+
+        it('loads every time when caching is disabled', async () => {
+            const { stores, release, getReads } = makeDeferredPartialsStore();
+            const service = makeService(stores);
+            const context = makeContext();
+
+            release();
+            await service.loadPartials(context, { useCache: false });
+            await service.loadPartials(context, { useCache: false });
+
+            assertEqual(2, getReads());
+        });
+
+        // A cached rejection would be replayed to every later caller for the life
+        // of the isolate, turning one transient storage failure into a permanent one.
+        it('does not retain a failed load', async () => {
+            const stores = makeStores();
+            let reads = 0;
+            stores.templateFileStore.getPartials = async () => {
+                reads += 1;
+                if (reads === 1) {
+                    throw new Error('transient storage failure');
+                }
+                return [ { filepath: 'partials/nav.html', source: 'Navigation' } ];
+            };
+            const service = makeService(stores);
+            const context = makeContext();
+
+            const caught = await catchAsyncError(() => service.loadPartials(context, { useCache: true }));
+            assert(caught, 'expected the first load to reject');
+            assertEqual('transient storage failure', caught.message);
+
+            const partials = await service.loadPartials(context, { useCache: true });
+
+            assertEqual(2, reads);
+            assert(partials.has('nav.html'), 'expected the retry to populate the partials');
+        });
+
+        it('propagates a failed shared load to every concurrent caller', async () => {
+            const stores = makeStores();
+            let reads = 0;
+            stores.templateFileStore.getPartials = async () => {
+                reads += 1;
+                throw new Error('transient storage failure');
+            };
+            const service = makeService(stores);
+            const context = makeContext();
+
+            const results = await Promise.allSettled([
+                service.loadPartials(context, { useCache: true }),
+                service.loadPartials(context, { useCache: true }),
+            ]);
+
+            assertEqual(1, reads);
+            assertEqual('rejected', results[0].status);
+            assertEqual('rejected', results[1].status);
+        });
+    });
+
     describe('publishing writes', ({ it }) => {
         it('writes page data to the page-relative logical filepaths', async () => {
             const stores = makeStores();

--- a/test/unit-tests/kixx/hyperview/hyperview-service.test.js
+++ b/test/unit-tests/kixx/hyperview/hyperview-service.test.js
@@ -57,7 +57,9 @@ function makeStores() {
             },
             async putBaseTemplate() {},
             async putPageTemplate() {},
-            async putPartial() {},
+            async putPartials() {
+                return [];
+            },
         },
     };
 }
@@ -729,8 +731,9 @@ describe('HyperviewService', ({ describe }) => {
             stores.templateFileStore.putPageTemplate = async () => {
                 writes += 1;
             };
-            stores.templateFileStore.putPartial = async () => {
+            stores.templateFileStore.putPartials = async () => {
                 writes += 1;
+                return [];
             };
             const service = makeService(stores);
 
@@ -743,8 +746,8 @@ describe('HyperviewService', ({ describe }) => {
                 'HyperviewService.putPageTemplate: templateId',
             );
             await assertIdentifierRejected(
-                () => service.putPartial(makeContext(), 'next', 'Nav.html', 'Navigation'),
-                'HyperviewService.putPartial: filepath',
+                () => service.putPartials(makeContext(), 'next', [ { filepath: 'Nav.html', source: 'Navigation' } ]),
+                'HyperviewService.putPartials: partials[].filepath',
             );
 
             assertEqual(0, writes);
@@ -759,21 +762,97 @@ describe('HyperviewService', ({ describe }) => {
             stores.templateFileStore.putPageTemplate = async (...args) => {
                 writes.push([ 'page', ...args ]);
             };
-            stores.templateFileStore.putPartial = async (...args) => {
-                writes.push([ 'partial', ...args ]);
+            stores.templateFileStore.putPartials = async (...args) => {
+                writes.push([ 'partials', ...args ]);
+                return [ { filepath: 'partials/shared/nav.html' } ];
             };
             const service = makeService(stores);
             const context = makeContext();
 
             await service.putBaseTemplate(context, 'next', 'site.html', 'Base');
             await service.putPageTemplate(context, 'next', 'blog/post.html', 'Page');
-            await service.putPartial(context, 'next', 'shared/nav.html', 'Partial');
+            await service.putPartials(context, 'next', [ { filepath: 'shared/nav.html', source: 'Partial' } ]);
 
             assertJSONEqual([
                 [ 'base', context, 'next', 'site.html', 'Base' ],
                 [ 'page', context, 'next', 'blog/post.html', 'Page' ],
-                [ 'partial', context, 'next', 'shared/nav.html', 'Partial' ],
+                [ 'partials', context, 'next', [ { filepath: 'shared/nav.html', source: 'Partial' } ] ],
             ], writes);
+        });
+
+        it('delegates once and returns the store result for a batch of partials', async () => {
+            const stores = makeStores();
+            let delegations = 0;
+            stores.templateFileStore.putPartials = async (_context, _buildId, partials) => {
+                delegations += 1;
+                return partials.map(({ filepath }) => ({ filepath: `partials/${ filepath }` }));
+            };
+            const service = makeService(stores);
+            const context = makeContext();
+
+            const result = await service.putPartials(context, 'next', [
+                { filepath: 'nav.html', source: 'Nav' },
+                { filepath: 'footer.html', source: 'Footer' },
+            ]);
+
+            assertEqual(1, delegations);
+            assertJSONEqual([
+                { filepath: 'partials/nav.html' },
+                { filepath: 'partials/footer.html' },
+            ], result);
+        });
+
+        it('accepts an empty partial set and delegates it unchanged', async () => {
+            const stores = makeStores();
+            let received;
+            stores.templateFileStore.putPartials = async (_context, _buildId, partials) => {
+                received = partials;
+                return [];
+            };
+            const service = makeService(stores);
+
+            const result = await service.putPartials(makeContext(), 'next', []);
+
+            assertJSONEqual([], received);
+            assertJSONEqual([], result);
+        });
+
+        it('rejects an empty source in a partial batch entry', async () => {
+            const stores = makeStores();
+            let writes = 0;
+            stores.templateFileStore.putPartials = async () => {
+                writes += 1;
+                return [];
+            };
+            const service = makeService(stores);
+
+            const caught = await catchAsyncError(() => service.putPartials(makeContext(), 'next', [
+                { filepath: 'nav.html', source: '' },
+            ]));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('HyperviewService.putPartials: partials[].source', caught.message);
+            assertEqual(0, writes);
+        });
+
+        it('rejects a partial batch write to the current build', async () => {
+            const stores = makeStores();
+            let writes = 0;
+            stores.templateFileStore.putPartials = async () => {
+                writes += 1;
+                return [];
+            };
+            const service = makeService(stores);
+            const context = makeContext('live');
+
+            const caught = await catchAsyncError(() => service.putPartials(context, 'live', [
+                { filepath: 'nav.html', source: 'Nav' },
+            ]));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertEqual(0, writes);
         });
     });
 });

--- a/test/unit-tests/plugins/cloudflare-document-store-engine/lib/document-store-engine.test.js
+++ b/test/unit-tests/plugins/cloudflare-document-store-engine/lib/document-store-engine.test.js
@@ -1,0 +1,486 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe } from 'kixx-test';
+import {
+    assert,
+    assertEqual,
+    assertMatches,
+} from 'kixx-assert';
+
+import DocumentStoreEngine from '../../../../../src/plugins/cloudflare-document-store-engine/lib/document-store-engine.js';
+import Logger from '../../../../../src/kixx/logger/logger.js';
+
+
+const openDatabases = [];
+
+/**
+ * Minimal D1 binding backed by node:sqlite.
+ *
+ * D1 is an HTTP facade over SQLite, so a real SQLite connection reproduces the
+ * behavior this engine depends on: PRAGMA result shape, the CREATE TABLE text
+ * SQLite stores in sqlite_master, generated-column semantics, and DDL inside a
+ * transaction. It cannot reproduce Cloudflare's API layer, so these tests prove
+ * the SQL and the migration logic are correct without proving that the D1 service
+ * accepts every statement shape.
+ */
+class MockD1Database {
+
+    constructor(database) {
+        this.database = database;
+        // Call counts stand in for network round trips, which is what prepareDatabase()
+        // is structured to minimize on a cold Worker isolate.
+        this.calls = { run: 0, first: 0, batch: 0 };
+    }
+
+    prepare(sql) {
+        return new MockD1PreparedStatement(this, sql, []);
+    }
+
+    async batch(statements) {
+        this.calls.batch += 1;
+
+        // D1 executes a batch in order inside an implicit transaction. Reproducing the
+        // transaction is the point: it is what makes a failed migration roll back as a
+        // unit instead of leaving a column without its index.
+        this.database.exec('BEGIN');
+        try {
+            const results = [];
+            for (const statement of statements) {
+                results.push(await statement.run());
+            }
+            this.database.exec('COMMIT');
+            return results;
+        } catch (error) {
+            this.database.exec('ROLLBACK');
+            throw error;
+        }
+    }
+
+    execute(sql, params) {
+        const statement = this.database.prepare(sql);
+        // all() returns rows for row-returning statements and [] for the rest, so a
+        // single path serves SELECT, PRAGMA, DDL, and INSERT ... RETURNING alike.
+        const results = statement.all(...params);
+        const { n } = this.database.prepare('SELECT changes() AS n').get();
+        return { results, changes: n };
+    }
+
+    resetCalls() {
+        this.calls = { run: 0, first: 0, batch: 0 };
+    }
+}
+
+class MockD1PreparedStatement {
+
+    #db;
+    #sql;
+    #params;
+
+    constructor(db, sql, params) {
+        this.#db = db;
+        this.#sql = sql;
+        this.#params = params;
+    }
+
+    bind(...params) {
+        return new MockD1PreparedStatement(this.#db, this.#sql, params);
+    }
+
+    async run() {
+        this.#db.calls.run += 1;
+        const { results, changes } = this.#db.execute(this.#sql, this.#params);
+        return { success: true, results, meta: { changes } };
+    }
+
+    async first() {
+        this.#db.calls.first += 1;
+        const { results } = this.#db.execute(this.#sql, this.#params);
+        return results.length > 0 ? results[0] : null;
+    }
+}
+
+function makeLogger() {
+    return new Logger({ name: 'Test', level: 'NONE' });
+}
+
+function makeDatabase() {
+    const database = new DatabaseSync(':memory:');
+    openDatabases.push(database);
+    return { database, db: new MockD1Database(database) };
+}
+
+function makeContext(db) {
+    return { config: {}, env: { DOCUMENT_STORE: db } };
+}
+
+/**
+ * Builds an engine as a freshly started Worker isolate would: a new instance with
+ * no memory of any previous migration, pointed at an existing database.
+ */
+function makeEngine(indexDefinitions) {
+    const engine = new DocumentStoreEngine({ logger: makeLogger() });
+    engine.setIndexDefinitions(indexDefinitions);
+    return engine;
+}
+
+function getKeyColumns(database) {
+    return database
+        .prepare('PRAGMA table_xinfo(documents)')
+        .all()
+        .map(({ name }) => name)
+        .filter((name) => name.startsWith('key_'))
+        .sort();
+}
+
+function getIndexNames(database) {
+    return database
+        .prepare('PRAGMA index_list(documents)')
+        .all()
+        .map(({ name }) => name)
+        .sort();
+}
+
+function isIndexUnique(database, indexName) {
+    const row = database
+        .prepare('PRAGMA index_list(documents)')
+        .all()
+        .find(({ name }) => name === indexName);
+    return row ? row.unique === 1 : null;
+}
+
+async function catchAsyncError(fn) {
+    try {
+        await fn();
+    } catch (error) {
+        return error;
+    }
+    return null;
+}
+
+describe('Cloudflare DocumentStoreEngine', ({ after, describe }) => {
+
+    after(() => {
+        for (const database of openDatabases) {
+            database.close();
+        }
+    });
+
+    describe('prepareDatabase() on a fresh database', ({ it }) => {
+        it('creates the documents table and the default sort key index', async () => {
+            const { database, db } = makeDatabase();
+            const engine = makeEngine([]);
+
+            await engine.prepareDatabase(makeContext(db));
+
+            const columns = database
+                .prepare('PRAGMA table_xinfo(documents)')
+                .all()
+                .map(({ name }) => name);
+
+            assertEqual(
+                'created_at,doc,id,sort_key,type,updated_at,version',
+                columns.sort().join(','),
+            );
+            assert(getIndexNames(database).includes('idx_type_sort_key'));
+        });
+
+        it('creates a generated column and index for every definition', async () => {
+            const { database, db } = makeDatabase();
+            const engine = makeEngine([
+                { name: 'by_title', jsonPath: '$.title' },
+                { name: 'by_email', jsonPath: '$.email', unique: true },
+            ]);
+
+            await engine.prepareDatabase(makeContext(db));
+
+            assertEqual('key_by_email,key_by_title', getKeyColumns(database).join(','));
+            assert(getIndexNames(database).includes('idx_type_custom_key_by_title'));
+            assertEqual(true, isIndexUnique(database, 'idx_type_custom_key_by_email'));
+            assertEqual(false, isIndexUnique(database, 'idx_type_custom_key_by_title'));
+        });
+
+        it('populates the generated column from stored JSON so queries match', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+            const engine = makeEngine([ { name: 'by_title', jsonPath: '$.title' } ]);
+
+            await engine.put(context, { type: 'Note', id: 'n1', title: 'Alpha' });
+            await engine.put(context, { type: 'Note', id: 'n2', title: 'Beta' });
+            const page = await engine.query(context, 'Note', {
+                index: 'by_title',
+                equalTo: 'Beta',
+            });
+
+            assertEqual(1, page.records.length);
+            assertEqual('n2', page.records[0].id);
+        });
+    });
+
+    describe('prepareDatabase() when the schema already matches', ({ it }) => {
+        it('issues no DDL and reads the schema exactly once', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+            const indexes = [ { name: 'by_title', jsonPath: '$.title' } ];
+
+            await makeEngine(indexes).prepareDatabase(context);
+            db.resetCalls();
+
+            // A second isolate starting against the already-migrated database.
+            await makeEngine(indexes).prepareDatabase(context);
+
+            // The two PRAGMAs go through run() and the sqlite_master read through
+            // first(). All three are issued concurrently, so this is one round trip
+            // of latency, and no batch() means no DDL was emitted at all.
+            assertEqual(0, db.calls.batch);
+            assertEqual(2, db.calls.run);
+            assertEqual(1, db.calls.first);
+        });
+
+        it('is idempotent across repeated migrations', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+            const indexes = [
+                { name: 'by_title', jsonPath: '$.title' },
+                { name: 'by_email', jsonPath: '$.email', unique: true },
+            ];
+
+            await makeEngine(indexes).prepareDatabase(context);
+            await makeEngine(indexes).prepareDatabase(context);
+            await makeEngine(indexes).prepareDatabase(context);
+
+            assertEqual('key_by_email,key_by_title', getKeyColumns(database).join(','));
+            assertEqual(true, isIndexUnique(database, 'idx_type_custom_key_by_email'));
+        });
+    });
+
+    describe('prepareDatabase() reconciliation', ({ it }) => {
+        it('rebuilds the generated column when jsonPath changes', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+
+            const before = makeEngine([ { name: 'by_label', jsonPath: '$.title' } ]);
+            await before.put(context, {
+                type: 'Note',
+                id: 'n1',
+                title: 'Alpha',
+                name: 'Zulu',
+            });
+
+            // A redeploy which repoints the same index at a different field. The column
+            // expression cannot be altered in place, so the migration has to drop and
+            // rebuild it. Recovering the old path depends on matching the CREATE TABLE
+            // text SQLite stored, which is what this assertion really exercises.
+            const afterEngine = makeEngine([ { name: 'by_label', jsonPath: '$.name' } ]);
+            await afterEngine.prepareDatabase(context);
+
+            const matched = await afterEngine.query(context, 'Note', {
+                index: 'by_label',
+                equalTo: 'Zulu',
+            });
+            const stale = await afterEngine.query(context, 'Note', {
+                index: 'by_label',
+                equalTo: 'Alpha',
+            });
+
+            assertEqual(1, matched.records.length);
+            assertEqual('n1', matched.records[0].id);
+            assertEqual(0, stale.records.length);
+        });
+
+        it('leaves the column alone when jsonPath is unchanged', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+            const indexes = [ { name: 'by_title', jsonPath: '$.title' } ];
+
+            await makeEngine(indexes).prepareDatabase(context);
+            db.resetCalls();
+            await makeEngine(indexes).prepareDatabase(context);
+
+            // A jsonPath the migration failed to recognize would look like a change and
+            // trigger a needless drop-and-rebuild of the column on every cold start.
+            assertEqual(0, db.calls.batch);
+        });
+
+        it('round trips a jsonPath containing a single quote', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+            const indexes = [ { name: 'by_odd', jsonPath: '$."odd\'name"' } ];
+
+            const engine = makeEngine(indexes);
+            await engine.put(context, { type: 'Note', id: 'n1', 'odd\'name': 'Quoted' });
+            const page = await engine.query(context, 'Note', {
+                index: 'by_odd',
+                equalTo: 'Quoted',
+            });
+
+            assertEqual(1, page.records.length);
+
+            // The quote must survive the SQL literal escaping in both directions, or the
+            // next migration reads back a different path and rebuilds the column forever.
+            db.resetCalls();
+            await makeEngine(indexes).prepareDatabase(context);
+
+            assertEqual(0, db.calls.batch);
+            assertEqual('key_by_odd', getKeyColumns(database).join(','));
+        });
+
+        it('drops the column and index when a definition is removed', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+
+            await makeEngine([
+                { name: 'by_title', jsonPath: '$.title' },
+                { name: 'by_email', jsonPath: '$.email' },
+            ]).prepareDatabase(context);
+
+            await makeEngine([
+                { name: 'by_title', jsonPath: '$.title' },
+            ]).prepareDatabase(context);
+
+            assertEqual('key_by_title', getKeyColumns(database).join(','));
+            assertEqual(false, getIndexNames(database).includes('idx_type_custom_key_by_email'));
+        });
+
+        it('recreates the default sort key index when it is missing', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+
+            await makeEngine([]).prepareDatabase(context);
+            // Simulates a migration interrupted between CREATE TABLE and CREATE INDEX.
+            database.exec('DROP INDEX idx_type_sort_key');
+
+            await makeEngine([]).prepareDatabase(context);
+
+            assert(getIndexNames(database).includes('idx_type_sort_key'));
+        });
+
+        it('recreates the index when a definition switches to unique', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+
+            await makeEngine([
+                { name: 'by_email', jsonPath: '$.email' },
+            ]).prepareDatabase(context);
+            assertEqual(false, isIndexUnique(database, 'idx_type_custom_key_by_email'));
+
+            await makeEngine([
+                { name: 'by_email', jsonPath: '$.email', unique: true },
+            ]).prepareDatabase(context);
+
+            assertEqual(true, isIndexUnique(database, 'idx_type_custom_key_by_email'));
+            // The column is not rebuilt for a uniqueness change; only the index is.
+            assertEqual('key_by_email', getKeyColumns(database).join(','));
+        });
+    });
+
+    describe('unique secondary indexes', ({ it }) => {
+        it('translates a SQLite unique constraint failure', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+            const engine = makeEngine([
+                { name: 'by_email', jsonPath: '$.email', unique: true },
+            ]);
+
+            await engine.put(context, { type: 'Note', id: 'n1', email: 'a@example.com' });
+            const caught = await catchAsyncError(() => {
+                return engine.put(context, { type: 'Note', id: 'n2', email: 'a@example.com' });
+            });
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('DocumentUniqueIndexViolationError', caught.name);
+            assertEqual('by_email', caught.indexName);
+        });
+
+        it('allows the same value under a different document type', async () => {
+            const { db } = makeDatabase();
+            const context = makeContext(db);
+            const engine = makeEngine([
+                { name: 'by_email', jsonPath: '$.email', unique: true },
+            ]);
+
+            await engine.put(context, { type: 'Note', id: 'n1', email: 'a@example.com' });
+            await engine.put(context, { type: 'Page', id: 'p1', email: 'a@example.com' });
+
+            const note = await engine.get(context, 'Note', 'n1');
+            const page = await engine.get(context, 'Page', 'p1');
+
+            assertEqual('a@example.com', note.doc.email);
+            assertEqual('a@example.com', page.doc.email);
+        });
+    });
+
+    describe('prepareDatabase() failure handling', ({ it }) => {
+        it('falls back to create-then-read when the first introspection fails', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+            let failures = 0;
+
+            // A database which has never been migrated is the case where introspection is
+            // least trustworthy, so the first read is allowed to fail without being fatal.
+            const execute = db.execute.bind(db);
+            db.execute = (sql, params) => {
+                if (sql.includes('table_xinfo') && failures === 0) {
+                    failures += 1;
+                    throw new Error('introspection unavailable');
+                }
+                return execute(sql, params);
+            };
+
+            await makeEngine([ { name: 'by_title', jsonPath: '$.title' } ])
+                .prepareDatabase(context);
+
+            assertEqual(1, failures);
+            assertEqual('key_by_title', getKeyColumns(database).join(','));
+        });
+
+        it('rebuilds a key column which is not a generated column', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+
+            await makeEngine([]).prepareDatabase(context);
+            // A plain column occupying the name the migration wants. There is no
+            // json_extract() expression to recover, so it reads as a changed path and is
+            // replaced rather than left in place silently extracting nothing.
+            database.exec('ALTER TABLE documents ADD COLUMN key_by_title TEXT');
+
+            const engine = makeEngine([ { name: 'by_title', jsonPath: '$.title' } ]);
+            await engine.put(context, { type: 'Note', id: 'n1', title: 'Alpha' });
+            const page = await engine.query(context, 'Note', {
+                index: 'by_title',
+                equalTo: 'Alpha',
+            });
+
+            assertEqual(1, page.records.length);
+        });
+
+        it('rolls back the whole migration when one statement fails', async () => {
+            const { database, db } = makeDatabase();
+            const context = makeContext(db);
+
+            await makeEngine([]).prepareDatabase(context);
+
+            const execute = db.execute.bind(db);
+            db.execute = (sql, params) => {
+                // Fail the CREATE INDEX so the ALTER TABLE ahead of it has already been
+                // applied inside the transaction by the time the batch aborts.
+                if (sql.includes('idx_type_custom_key_by_title')) {
+                    throw new Error('D1 statement failed');
+                }
+                return execute(sql, params);
+            };
+
+            const caught = await catchAsyncError(() => {
+                return makeEngine([ { name: 'by_title', jsonPath: '$.title' } ])
+                    .prepareDatabase(context);
+            });
+            db.execute = execute;
+
+            assert(caught, 'expected an error to be thrown');
+            assertMatches('Unable to reconcile secondary indexes', caught.message);
+            assertEqual('D1 statement failed', caught.cause.message);
+            // Without the transaction the column would survive without its index, which
+            // is the half-migrated state a statement-at-a-time migration can leave behind.
+            assertEqual('', getKeyColumns(database).join(','));
+        });
+    });
+});

--- a/test/unit-tests/plugins/cloudflare-hyperview-page-data-store/lib/page-data-store.test.js
+++ b/test/unit-tests/plugins/cloudflare-hyperview-page-data-store/lib/page-data-store.test.js
@@ -14,9 +14,11 @@ function makeLogger() {
 // `{namespace}/{filepath}` encoding rather than mocking it. The double honors
 // the `{ type }` option the way Cloudflare KV does: `type: 'json'` parses the
 // stored text, matching how `PageDataStore` stores serialized JSON on write and
-// expects parsed values on read.
+// expects parsed values on read. Every read's options are recorded on
+// `readOptions` so tests can assert the cacheTtl handed to the platform.
 function makeKVNamespace(initial) {
     const store = new Map(Object.entries(initial ?? {}));
+    const readOptions = [];
 
     function decode(raw, type) {
         if (raw === null || raw === undefined) {
@@ -27,7 +29,9 @@ function makeKVNamespace(initial) {
 
     return {
         store,
+        readOptions,
         async get(key, options) {
+            readOptions.push(options);
             const type = options?.type;
             if (Array.isArray(key)) {
                 const result = new Map();
@@ -44,8 +48,18 @@ function makeKVNamespace(initial) {
     };
 }
 
-function makeContext(kvStore) {
-    return { env: { HYPERVIEW_PAGE_DATA_STORE: kvStore ?? makeKVNamespace() } };
+// `config` is optional so the majority of tests, which do not care about the
+// cache TTL, exercise the built-in default the same way an unconfigured
+// deployment would.
+function makeContext(kvStore, config) {
+    return {
+        env: { HYPERVIEW_PAGE_DATA_STORE: kvStore ?? makeKVNamespace() },
+        config,
+    };
+}
+
+function makeConfig(pageDataStoreConfig) {
+    return { env: { HYPERVIEW_PAGE_DATA_STORE: pageDataStoreConfig } };
 }
 
 function makeStore() {
@@ -360,6 +374,83 @@ describe('PageDataStore', ({ describe }) => {
             assertEqual('# Body', kvStore.store.get('body.md'));
             const result = await store.getTextFile(context, null, '/body.md');
             assertEqual('# Body', result);
+        });
+    });
+
+    describe('read cache TTL', ({ it }) => {
+        it('applies the default TTL to getJSONFiles', async () => {
+            const kvStore = makeKVNamespace();
+            const store = makeStore();
+
+            await store.getJSONFiles(makeContext(kvStore), 'v1', [ '/page.json' ]);
+
+            assertEqual(1, kvStore.readOptions.length);
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+            assertEqual('json', kvStore.readOptions[0].type);
+        });
+
+        it('applies the default TTL to getTextFiles', async () => {
+            const kvStore = makeKVNamespace();
+            const store = makeStore();
+
+            await store.getTextFiles(makeContext(kvStore), 'v1', [ '/body.md' ]);
+
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+            assertEqual('text', kvStore.readOptions[0].type);
+        });
+
+        it('applies the default TTL to getTextFile', async () => {
+            const kvStore = makeKVNamespace();
+            const store = makeStore();
+
+            await store.getTextFile(makeContext(kvStore), 'v1', '/body.md');
+
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+            assertEqual('text', kvStore.readOptions[0].type);
+        });
+
+        it('uses the configured cacheTtl', async () => {
+            const kvStore = makeKVNamespace();
+            const config = makeConfig({ cacheTtl: 900 });
+            const store = makeStore();
+
+            await store.getTextFile(makeContext(kvStore, config), 'v1', '/body.md');
+
+            assertEqual(900, kvStore.readOptions[0].cacheTtl);
+        });
+
+        // Page data may be published into the live build's namespace, so unlike
+        // template files it is no more immutable when namespaced.
+        it('uses the same TTL with and without a namespace', async () => {
+            const kvStore = makeKVNamespace();
+            const context = makeContext(kvStore);
+            const store = makeStore();
+
+            await store.getTextFile(context, 'v1', '/body.md');
+            await store.getTextFile(context, null, '/body.md');
+
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+            assertEqual(300, kvStore.readOptions[1].cacheTtl);
+        });
+
+        it('throws when the configured cacheTtl is below the Cloudflare minimum', async () => {
+            const store = makeStore();
+            const context = makeContext(null, makeConfig({ cacheTtl: 29 }));
+            const caught = await catchAsyncError(() => store.getTextFile(context, 'v1', '/body.md'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('at least 30 seconds', caught.message);
+        });
+
+        it('throws when the configured cacheTtl is not an integer', async () => {
+            const store = makeStore();
+            const context = makeContext(null, makeConfig({ cacheTtl: '300' }));
+            const caught = await catchAsyncError(() => store.getTextFile(context, 'v1', '/body.md'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('must be an integer', caught.message);
         });
     });
 });

--- a/test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js
+++ b/test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js
@@ -30,7 +30,13 @@ function makeKVNamespace(initial) {
                 }
                 return result;
             }
-            return store.has(key) ? store.get(key) : null;
+            if (!store.has(key)) {
+                return null;
+            }
+            const value = store.get(key);
+            // Mirror Cloudflare KV, which parses JSON values for the caller when
+            // { type: 'json' } is requested.
+            return options?.type === 'json' ? JSON.parse(value) : value;
         },
         async put(key, value) {
             store.set(key, value);
@@ -349,8 +355,8 @@ describe('TemplateFileStore', ({ describe }) => {
         });
     });
 
-    describe('putPartial and getPartials', ({ it }) => {
-        it('returns an empty array when no partials exist', async () => {
+    describe('putPartials and getPartials', ({ it }) => {
+        it('returns an empty array for the flat namespace when no partials exist', async () => {
             const store = makeStore();
 
             const result = await store.getPartials(makeContext(), null);
@@ -358,54 +364,175 @@ describe('TemplateFileStore', ({ describe }) => {
             assertEqual(0, result.length);
         });
 
-        it('writes a partial under the partials prefix and round-trips through getPartials', async () => {
+        it('throws when a namespaced partial manifest was never published', async () => {
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('no published partial manifest', caught.message);
+        });
+
+        it('writes one manifest value and round-trips through getPartials, in submitted order', async () => {
             const kvStore = makeKVNamespace();
             const context = makeContext(kvStore);
             const store = makeStore();
 
-            const written = await store.putPartial(context, null, 'nav.html', '<nav/>');
-            assertEqual('partials/nav.html', written.filepath);
+            const written = await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav/>' },
+                { filepath: 'footer.html', source: '<footer/>' },
+            ]);
 
-            const result = await store.getPartials(context, null);
-            assertEqual(1, result.length);
-            assertEqual('partials/nav.html', result[0].filepath);
-            assertEqual('<nav/>', result[0].source);
+            assertEqual(2, written.length);
+            assertEqual('partials/nav.html', written[0].filepath);
+            assertEqual('partials/footer.html', written[1].filepath);
+
+            assertEqual(1, kvStore.store.size);
+            assertEqual(
+                JSON.stringify({ 'partials/nav.html': '<nav/>', 'partials/footer.html': '<footer/>' }),
+                kvStore.store.get('v1/partials.json'),
+            );
+
+            const result = await store.getPartials(context, 'v1');
+            const byFilepath = new Map(result.map((file) => [ file.filepath, file.source ]));
+            assertEqual(2, result.length);
+            assertEqual('<nav/>', byFilepath.get('partials/nav.html'));
+            assertEqual('<footer/>', byFilepath.get('partials/footer.html'));
         });
 
-        it('returns logical filepaths with the namespace stripped', async () => {
+        it('reads the manifest through one cacheable JSON get() at the configured TTL', async () => {
+            const kvStore = makeKVNamespace();
+            const context = makeContext(kvStore);
+            const store = makeStore();
+
+            await store.putPartials(context, 'v1', [ { filepath: 'nav.html', source: '<nav/>' } ]);
+            await store.getPartials(context, 'v1');
+
+            assertEqual(1, kvStore.readOptions.length);
+            assertEqual('json', kvStore.readOptions[0].type);
+            assertEqual(86400, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('publishes an explicitly empty manifest that resolves to an empty array rather than failing', async () => {
+            const kvStore = makeKVNamespace();
+            const context = makeContext(kvStore);
+            const store = makeStore();
+
+            const written = await store.putPartials(context, 'v1', []);
+            assertEqual(0, written.length);
+            assertEqual('{}', kvStore.store.get('v1/partials.json'));
+
+            const result = await store.getPartials(context, 'v1');
+            assertEqual(0, result.length);
+        });
+
+        it('replaces the complete manifest, dropping a key omitted from a later successful batch', async () => {
+            const kvStore = makeKVNamespace();
+            const context = makeContext(kvStore);
+            const store = makeStore();
+
+            await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav/>' },
+                { filepath: 'footer.html', source: '<footer/>' },
+            ]);
+            await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav-2/>' },
+            ]);
+
+            const result = await store.getPartials(context, 'v1');
+
+            assertEqual(1, result.length);
+            assertEqual('partials/nav.html', result[0].filepath);
+            assertEqual('<nav-2/>', result[0].source);
+        });
+
+        it('ignores legacy per-partial keys written under the namespace', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials/legacy.html': '<legacy/>' });
+            const context = makeContext(kvStore);
+            const store = makeStore();
+
+            await store.putPartials(context, 'v1', [ { filepath: 'nav.html', source: '<nav/>' } ]);
+            const result = await store.getPartials(context, 'v1');
+
+            assertEqual(1, result.length);
+            assertEqual('partials/nav.html', result[0].filepath);
+        });
+
+        it('throws when putPartials is called without a namespace', async () => {
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.putPartials(makeContext(), null, []));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('putPartials requires a non-empty namespace', caught.message);
+        });
+
+        it('throws when the stored manifest is not a JSON object', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify([ 'nav.html' ]) });
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(kvStore), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('must be a JSON object', caught.message);
+        });
+
+        it('throws when a manifest key is outside the partials prefix', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify({ 'base/home.html': '<home/>' }) });
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(kvStore), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('invalid key', caught.message);
+        });
+
+        it('throws when a manifest key is not lower case', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify({ 'partials/Nav.html': '<nav/>' }) });
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(kvStore), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('invalid key', caught.message);
+        });
+
+        it('throws when a manifest key has an empty path segment', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify({ 'partials//nav.html': '<nav/>' }) });
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(kvStore), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('invalid key', caught.message);
+        });
+
+        it('throws when a manifest value is not a non-empty string', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify({ 'partials/nav.html': '' }) });
+            const store = makeStore();
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(kvStore), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('invalid source', caught.message);
+        });
+
+        it('does not normalize manifest keys or values on read', async () => {
             const kvStore = makeKVNamespace({
-                'v1/partials/nav.html': '<nav/>',
-                'v1/partials/footer.html': '<footer/>',
+                'v1/partials.json': JSON.stringify({ 'partials/nav.html': '  <nav/>  ' }),
             });
             const store = makeStore();
 
             const result = await store.getPartials(makeContext(kvStore), 'v1');
 
-            const filepaths = result.map((file) => file.filepath).sort();
-            assertEqual('partials/footer.html', filepaths[0]);
-            assertEqual('partials/nav.html', filepaths[1]);
-        });
-
-        it('does not return files from another prefix', async () => {
-            const kvStore = makeKVNamespace({
-                'partials/nav.html': '<nav/>',
-                'base/home.html': '<home/>',
-            });
-            const store = makeStore();
-
-            const result = await store.getPartials(makeContext(kvStore), null);
-
-            assertEqual(1, result.length);
-            assertEqual('partials/nav.html', result[0].filepath);
-        });
-
-        it('does not return partials written under a different namespace', async () => {
-            const kvStore = makeKVNamespace({ 'v1/partials/nav.html': '<nav/>' });
-            const store = makeStore();
-
-            const result = await store.getPartials(makeContext(kvStore), 'v2');
-
-            assertEqual(0, result.length);
+            assertEqual('  <nav/>  ', result[0].source);
         });
     });
 
@@ -452,8 +579,8 @@ describe('TemplateFileStore', ({ describe }) => {
             assertEqual(86400, kvStore.readOptions[0].cacheTtl);
         });
 
-        it('applies the TTL to the getPartials bulk read', async () => {
-            const kvStore = makeKVNamespace({ 'v1/partials/nav.html': '<nav/>' });
+        it('applies the TTL to the getPartials manifest read', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials.json': JSON.stringify({ 'partials/nav.html': '<nav/>' }) });
             const store = makeStore();
 
             await store.getPartials(makeContext(kvStore), 'v1');

--- a/test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js
+++ b/test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js
@@ -12,12 +12,17 @@ function makeLogger() {
 // Minimal Cloudflare KV namespace double. Backed by a single Map so reads,
 // writes, and prefix listings all operate over the same stored keys, exercising
 // the real `{namespace}/{prefix}{filepath}` encoding rather than mocking it.
+// Every read's options are recorded on `readOptions` so tests can assert the
+// cacheTtl handed to the platform.
 function makeKVNamespace(initial) {
     const store = new Map(Object.entries(initial ?? {}));
+    const readOptions = [];
 
     return {
         store,
-        async get(key) {
+        readOptions,
+        async get(key, options) {
+            readOptions.push(options);
             if (Array.isArray(key)) {
                 const result = new Map();
                 for (const name of key) {
@@ -42,8 +47,18 @@ function makeKVNamespace(initial) {
     };
 }
 
-function makeContext(kvStore) {
-    return { env: { HYPERVIEW_TEMPLATE_FILE_STORE: kvStore ?? makeKVNamespace() } };
+// `config` is optional so the majority of tests, which do not care about the
+// cache TTL, exercise the built-in defaults the same way an unconfigured
+// deployment would.
+function makeContext(kvStore, config) {
+    return {
+        env: { HYPERVIEW_TEMPLATE_FILE_STORE: kvStore ?? makeKVNamespace() },
+        config,
+    };
+}
+
+function makeConfig(templateFileStoreConfig) {
+    return { env: { HYPERVIEW_TEMPLATE_FILE_STORE: templateFileStoreConfig } };
 }
 
 function makeStore() {
@@ -391,6 +406,102 @@ describe('TemplateFileStore', ({ describe }) => {
             const result = await store.getPartials(makeContext(kvStore), 'v2');
 
             assertEqual(0, result.length);
+        });
+    });
+
+    describe('read cache TTL', ({ it }) => {
+        // A build never rewrites its own templates, so a namespaced key can be
+        // cached for as long as the build lives.
+        it('applies the long default TTL to a namespaced read', async () => {
+            const kvStore = makeKVNamespace({ 'v1/base/home.html': '<home/>' });
+            const store = makeStore();
+
+            await store.getBaseTemplate(makeContext(kvStore), 'v1', 'home.html');
+
+            assertEqual(1, kvStore.readOptions.length);
+            assertEqual(86400, kvStore.readOptions[0].cacheTtl);
+            assertEqual('text', kvStore.readOptions[0].type);
+        });
+
+        // Flat keys carry no build-id immutability guarantee, so they must not
+        // inherit the long TTL.
+        it('caps the TTL for an un-namespaced read', async () => {
+            const kvStore = makeKVNamespace({ 'base/home.html': '<home/>' });
+            const store = makeStore();
+
+            await store.getBaseTemplate(makeContext(kvStore), null, 'home.html');
+
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('treats an empty-string namespace as un-namespaced for the TTL', async () => {
+            const kvStore = makeKVNamespace({ 'base/home.html': '<home/>' });
+            const store = makeStore();
+
+            await store.getBaseTemplate(makeContext(kvStore), '', 'home.html');
+
+            assertEqual(300, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('applies the TTL to page template reads', async () => {
+            const kvStore = makeKVNamespace({ 'v1/pages/blog/page.html': '<page/>' });
+            const store = makeStore();
+
+            await store.getPageTemplate(makeContext(kvStore), 'v1', 'blog/page.html');
+
+            assertEqual(86400, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('applies the TTL to the getPartials bulk read', async () => {
+            const kvStore = makeKVNamespace({ 'v1/partials/nav.html': '<nav/>' });
+            const store = makeStore();
+
+            await store.getPartials(makeContext(kvStore), 'v1');
+
+            assertEqual(1, kvStore.readOptions.length);
+            assertEqual(86400, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('uses the configured cacheTtl for a namespaced read', async () => {
+            const kvStore = makeKVNamespace({ 'v1/base/home.html': '<home/>' });
+            const config = makeConfig({ cacheTtl: 604800 });
+            const store = makeStore();
+
+            await store.getBaseTemplate(makeContext(kvStore, config), 'v1', 'home.html');
+
+            assertEqual(604800, kvStore.readOptions[0].cacheTtl);
+        });
+
+        // The cap clamps rather than substitutes, so a deployment which asks for
+        // a TTL shorter than the cap still gets the shorter value.
+        it('keeps a configured TTL shorter than the un-namespaced cap', async () => {
+            const kvStore = makeKVNamespace({ 'base/home.html': '<home/>' });
+            const config = makeConfig({ cacheTtl: 60 });
+            const store = makeStore();
+
+            await store.getBaseTemplate(makeContext(kvStore, config), null, 'home.html');
+
+            assertEqual(60, kvStore.readOptions[0].cacheTtl);
+        });
+
+        it('throws when the configured cacheTtl is below the Cloudflare minimum', async () => {
+            const store = makeStore();
+            const context = makeContext(null, makeConfig({ cacheTtl: 29 }));
+            const caught = await catchAsyncError(() => store.getBaseTemplate(context, 'v1', 'home.html'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('at least 30 seconds', caught.message);
+        });
+
+        it('throws when the configured cacheTtl is not an integer', async () => {
+            const store = makeStore();
+            const context = makeContext(null, makeConfig({ cacheTtl: 86400.5 }));
+            const caught = await catchAsyncError(() => store.getBaseTemplate(context, 'v1', 'home.html'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('must be an integer', caught.message);
         });
     });
 });

--- a/test/unit-tests/plugins/node-document-store-engine/lib/document-store-engine.test.js
+++ b/test/unit-tests/plugins/node-document-store-engine/lib/document-store-engine.test.js
@@ -44,6 +44,19 @@ function catchError(fn) {
     return null;
 }
 
+function getTableSQL(database) {
+    const row = database
+        .prepare('SELECT sql FROM sqlite_master WHERE type = ? AND name = ?')
+        .get('table', 'documents');
+    return row?.sql ?? '';
+}
+
+function makeEngine(database, indexDefinitions) {
+    const engine = new DocumentStoreEngine({ logger: makeLogger(), database });
+    engine.setIndexDefinitions(indexDefinitions);
+    return engine;
+}
+
 describe('Node DocumentStoreEngine', ({ after, describe }) => {
 
     after(async () => {
@@ -267,6 +280,87 @@ describe('Node DocumentStoreEngine', ({ after, describe }) => {
             assertUndefined(documentPayload.type);
             assertUndefined(documentPayload.id);
             assertUndefined(documentPayload.sortKey);
+
+            engine.close();
+            database.close();
+        });
+    });
+
+    describe('generated column reconciliation', ({ it }) => {
+        it('rebuilds the generated column when jsonPath changes', async () => {
+            const database = new DatabaseSync(':memory:');
+
+            const before = makeEngine(database, [ { name: 'by_label', jsonPath: '$.title' } ]);
+            await before.put(null, {
+                type: 'Note',
+                id: 'n1',
+                title: 'Alpha',
+                name: 'Zulu',
+            });
+
+            // A redeploy repointing the same index at a different field. A generated
+            // column expression cannot be altered in place, so the migration drops and
+            // rebuilds it. Recovering the old path depends on matching the CREATE TABLE
+            // text SQLite stored, which is what this assertion really exercises.
+            const after = makeEngine(database, [ { name: 'by_label', jsonPath: '$.name' } ]);
+            await after.prepareDatabase(null);
+
+            const matched = await after.query(null, 'Note', {
+                index: 'by_label',
+                equalTo: 'Zulu',
+            });
+            const stale = await after.query(null, 'Note', {
+                index: 'by_label',
+                equalTo: 'Alpha',
+            });
+
+            assertEqual(1, matched.records.length);
+            assertEqual('n1', matched.records[0].id);
+            assertEqual(0, stale.records.length);
+
+            after.close();
+            database.close();
+        });
+
+        it('leaves the generated column in place when jsonPath is unchanged', async () => {
+            const database = new DatabaseSync(':memory:');
+            const indexes = [
+                { name: 'by_title', jsonPath: '$.title' },
+                { name: 'by_email', jsonPath: '$.email' },
+            ];
+
+            await makeEngine(database, indexes).prepareDatabase(null);
+            const tableSQL = getTableSQL(database);
+
+            await makeEngine(database, indexes).prepareDatabase(null);
+
+            // A path the migration failed to read back would look like a change and
+            // rebuild both columns, appending them to the stored table text in a new
+            // order. Byte equality is the cheapest proof that nothing was touched.
+            assertEqual(tableSQL, getTableSQL(database));
+
+            database.close();
+        });
+
+        it('round trips a jsonPath containing a single quote', async () => {
+            const database = new DatabaseSync(':memory:');
+            const indexes = [ { name: 'by_odd', jsonPath: '$."odd\'name"' } ];
+
+            const engine = makeEngine(database, indexes);
+            await engine.put(null, { type: 'Note', id: 'n1', 'odd\'name': 'Quoted' });
+            const page = await engine.query(null, 'Note', {
+                index: 'by_odd',
+                equalTo: 'Quoted',
+            });
+
+            assertEqual(1, page.records.length);
+
+            // The quote must survive SQL literal escaping in both directions, or the next
+            // migration reads back a different path and rebuilds the column forever.
+            const tableSQL = getTableSQL(database);
+            await makeEngine(database, indexes).prepareDatabase(null);
+
+            assertEqual(tableSQL, getTableSQL(database));
 
             engine.close();
             database.close();

--- a/test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js
+++ b/test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js
@@ -401,8 +401,8 @@ describe('TemplateFileStore (node)', ({ after, describe }) => {
         });
     });
 
-    describe('putPartial and getPartials', ({ it }) => {
-        it('returns an empty array when no partials exist', async () => {
+    describe('putPartials and getPartials', ({ it }) => {
+        it('returns an empty array for the flat namespace when no partials exist', async () => {
             const directory = await makeTempDir();
             const store = makeStore(directory);
 
@@ -411,46 +411,110 @@ describe('TemplateFileStore (node)', ({ after, describe }) => {
             assertEqual(0, result.length);
         });
 
-        it('writes a partial under the partials prefix and round-trips through getPartials', async () => {
+        it('throws when a namespaced partials directory was never published', async () => {
+            const directory = await makeTempDir();
+            const store = makeStore(directory);
+
+            const caught = await catchAsyncError(() => store.getPartials(makeContext(), 'v1'));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('no published partials directory', caught.message);
+        });
+
+        it('writes a complete set under the partials prefix and round-trips through getPartials, in submitted order', async () => {
             const directory = await makeTempDir();
             const context = makeContext();
             const store = makeStore(directory);
 
-            const written = await store.putPartial(context, null, 'nav.html', '<nav/>');
-            assertEqual('partials/nav.html', written.filepath);
+            const written = await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav/>' },
+                { filepath: 'footer.html', source: '<footer/>' },
+            ]);
 
-            const result = await store.getPartials(context, null);
-            assertEqual(1, result.length);
-            assertEqual('partials/nav.html', result[0].filepath);
-            assertEqual('<nav/>', result[0].source);
+            assertEqual(2, written.length);
+            assertEqual('partials/nav.html', written[0].filepath);
+            assertEqual('partials/footer.html', written[1].filepath);
+
+            const result = await store.getPartials(context, 'v1');
+            const byFilepath = new Map(result.map((file) => [ file.filepath, file.source ]));
+            assertEqual(2, result.length);
+            assertEqual('<nav/>', byFilepath.get('partials/nav.html'));
+            assertEqual('<footer/>', byFilepath.get('partials/footer.html'));
         });
 
-        it('returns logical filepaths with the namespace stripped', async () => {
+        it('writes nested partials with their full logical filepath', async () => {
             const directory = await makeTempDir();
-            await seedFile(directory, 'v1/partials/nav.html', '<nav/>');
-            await seedFile(directory, 'v1/partials/footer.html', '<footer/>');
             const store = makeStore(directory);
+
+            const written = await store.putPartials(makeContext(), 'v1', [
+                { filepath: 'widgets/card.html', source: '<card/>' },
+            ]);
+
+            assertEqual('partials/widgets/card.html', written[0].filepath);
+            assertEqual('<card/>', await readBackingFile(directory, 'v1/partials/widgets/card.html'));
+        });
+
+        it('publishes an explicitly empty set that resolves to an empty array rather than failing', async () => {
+            const directory = await makeTempDir();
+            const store = makeStore(directory);
+
+            const written = await store.putPartials(makeContext(), 'v1', []);
+            assertEqual(0, written.length);
 
             const result = await store.getPartials(makeContext(), 'v1');
-
-            const filepaths = result.map((file) => file.filepath).sort();
-            assertEqual('partials/footer.html', filepaths[0]);
-            assertEqual('partials/nav.html', filepaths[1]);
+            assertEqual(0, result.length);
         });
 
-        it('returns nested partials with their full logical filepath', async () => {
+        it('replaces the complete set, removing a file omitted from a later successful batch', async () => {
             const directory = await makeTempDir();
-            await seedFile(directory, 'partials/widgets/card.html', '<card/>');
+            const context = makeContext();
             const store = makeStore(directory);
 
-            const result = await store.getPartials(makeContext(), null);
+            await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav/>' },
+                { filepath: 'footer.html', source: '<footer/>' },
+            ]);
+            await store.putPartials(context, 'v1', [
+                { filepath: 'nav.html', source: '<nav-2/>' },
+            ]);
+
+            const result = await store.getPartials(context, 'v1');
 
             assertEqual(1, result.length);
-            assertEqual('partials/widgets/card.html', result[0].filepath);
-            assertEqual('<card/>', result[0].source);
+            assertEqual('partials/nav.html', result[0].filepath);
+            assertEqual('<nav-2/>', result[0].source);
         });
 
-        it('does not return files from another prefix', async () => {
+        it('does not touch other template prefixes or namespaces when replacing partials', async () => {
+            const directory = await makeTempDir();
+            const context = makeContext();
+            const store = makeStore(directory);
+
+            await store.putBaseTemplate(context, 'v1', 'home.html', '<home/>');
+            await seedFile(directory, 'v2/partials/nav.html', '<nav-v2/>');
+
+            await store.putPartials(context, 'v1', [ { filepath: 'nav.html', source: '<nav/>' } ]);
+            await store.putPartials(context, 'v1', [ { filepath: 'footer.html', source: '<footer/>' } ]);
+
+            assertEqual('<home/>', await readBackingFile(directory, 'v1/base/home.html'));
+            const v2Result = await store.getPartials(context, 'v2');
+            assertEqual(1, v2Result.length);
+            assertEqual('<nav-v2/>', v2Result[0].source);
+        });
+
+        it('throws when putPartials is called without a namespace', async () => {
+            const directory = await makeTempDir();
+            const store = makeStore(directory);
+
+            const caught = await catchAsyncError(() => store.putPartials(makeContext(), null, []));
+
+            assert(caught, 'expected an error to be thrown');
+            assertEqual('AssertionError', caught.name);
+            assertMatches('putPartials requires a non-empty namespace', caught.message);
+        });
+
+        it('does not return files from another prefix in the flat namespace', async () => {
             const directory = await makeTempDir();
             await seedFile(directory, 'partials/nav.html', '<nav/>');
             await seedFile(directory, 'base/home.html', '<home/>');
@@ -460,16 +524,6 @@ describe('TemplateFileStore (node)', ({ after, describe }) => {
 
             assertEqual(1, result.length);
             assertEqual('partials/nav.html', result[0].filepath);
-        });
-
-        it('does not return partials written under a different namespace', async () => {
-            const directory = await makeTempDir();
-            await seedFile(directory, 'v1/partials/nav.html', '<nav/>');
-            const store = makeStore(directory);
-
-            const result = await store.getPartials(makeContext(), 'v2');
-
-            assertEqual(0, result.length);
         });
     });
 });


### PR DESCRIPTION
# Batch Partial Template Manifest Implementation Plan

## Implementation Approach

Replace per-file partial-template publishing with one complete-set `PUT` and make that batch the portable operation exposed by Hyperview. The shared contract will remove `putPartial()` in favor of `putPartials(context, namespace, partials)`, require a non-empty namespace for writes, and define successful replacement and return-value semantics without promising transactional recovery after a failed write or ordering concurrent writes.

The two platform adapters will preserve their natural storage layouts. Cloudflare will store a namespaced build's complete partial set in one JSON value at `{buildId}/partials.json` and load it with one cacheable `get()`; Node will keep individual files under `{root}/{buildId}/partials/` and replace only that directory. Un-namespaced reads retain their existing filesystem traversal or KV `list()` plus `get()` behavior. A missing namespaced set is an invariant failure on both platforms, while an explicitly published empty set reads as `[]`. Legacy namespaced partial keys are neither read, migrated, backfilled, nor deleted.

The Publishing API will expose `PUT /publishing-api/v1/templates/partials{/}` as a JSON:API `PartialTemplateSet` replacement endpoint. It will reuse the existing template permission and Build ID safety rules, require a trustworthy `Content-Length` no greater than 25 MiB before buffering, normalize and validate the whole collection through a dedicated Form, and return only normalized file references. Base and page templates remain per-file resources. The old partial wildcard endpoint and all single-partial application methods will be removed.

Cross-cutting constraints:

- The publishing client must serialize batch writes for one Build ID and wait for publishing to succeed before deploying that Build ID. No lock, version check, or separate seal endpoint will be added.
- Sequential replacements of a staged Build ID remain allowed; writes to the current live Build ID remain forbidden.
- Source strings are ordinary UTF-8 JSON strings and are preserved after JSON decoding. Sources are not trimmed or Base64-encoded.
- The authenticated endpoint trusts the declared `Content-Length`; it does not buffer and recount bytes for enforcement.
- Unit tests and linting are required. Existing E2E tests will be rewritten for the new contract but must not be run.
- No dependency installation, development server, remote smoke test, migration, or new API documentation guide is in scope.

### Task BPTM-1: Establish the complete partial-set port and Hyperview service contract

**Status:** Not started
**Depends on:** None
**Documentation:** `src/plugins/README.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `src/kixx/hyperview/template-file-store-interface.js`

**Objective**

Make complete-set partial publication the only shared write capability exposed by Hyperview, so application code cannot publish a single partial or bypass the build-level replacement invariant.

**Scope**

- In: Update the template-file-store interface types and invariants; replace `HyperviewService.putPartial()` with `putPartials()`; validate service inputs and the non-current Build ID; return written logical file references in submitted order; update Hyperview service unit tests and test doubles.
- Out: Platform storage encodings, HTTP payload parsing, Forms, routes, transaction scripts, and E2E tests.

**Design and invariants**

- `putPartials(context, namespace, partials)` accepts an array of `{ filepath, source }` entries whose filepaths are relative to `partials/`.
- A write namespace is mandatory and non-empty. Read methods retain their existing optional namespace convention.
- A successful call replaces the namespace's complete logical partial set and resolves to `{ filepath }[]` using prefix-included logical paths such as `partials/website/nav.html`, in submitted order. An empty input resolves to `[]`.
- The contract promises the exact set only after successful resolution. A failed write may leave an incomplete staged namespace, which must be retried or abandoned.
- Concurrent calls for one namespace are outside the contract; callers must serialize them.
- `getPartials()` keeps its existing `{ filepath, source }[]` return shape and unspecified listing order.
- For namespaced reads, a never-published partial set is an invariant failure; an explicitly published empty set returns `[]`. Un-namespaced absence continues to return `[]`.
- `HyperviewService` remains the owner of the rule that a template write must target a valid Build ID other than the current runtime Build ID. It asserts the canonical normalized filepath and non-empty source of every entry before delegating once.
- Remove the single-partial method rather than retaining an internal compatibility path.

**Expected touch points**

- `src/kixx/hyperview/template-file-store-interface.js` — replace the single-write property, add precise batch input/result types, and document replacement, namespace, failure, and concurrency guarantees.
- `src/kixx/hyperview/hyperview-service.js` — replace `putPartial()` with the batch service method and preserve live-build protection.
- `test/unit-tests/kixx/hyperview/hyperview-service.test.js` — cover delegation, ordering, empty input, canonical input assertions, source assertions, required Build ID, and current-build rejection.
- Other unit-test doubles implementing `TemplateFileStoreInterface` — rename the removed method where required to keep tests structurally valid.

Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] No production Hyperview or port API exposes `putPartial()`.
- [ ] `putPartials()` accepts only a namespaced complete set, delegates once, and returns prefix-included references in input order.
- [ ] Empty-set publication and successful replacement semantics are documented without promising failure atomicity or concurrent-write ordering.
- [ ] Namespaced unpublished-set failure versus explicitly empty-set success is part of the portable read contract.
- [ ] Hyperview service unit tests cover the new method's success and invariant failures.

**Validation**

- `node run-linter.js src/kixx/hyperview/template-file-store-interface.js src/kixx/hyperview/hyperview-service.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — validates changed contract, service, and tests.
- `node run-tests.js test/unit-tests/kixx/hyperview/hyperview-service.test.js` — proves the service-level batch contract and build protections.
- `rg -n "putPartial\\(" src test/unit-tests --glob '*.js'` — identifies any single-partial production path or stale unit-test double remaining for later tasks.

**Progress and handoff**

- Completed: Nothing yet.
- Current state: Not started.
- Remaining: Everything described above.
- Decisions and discoveries: The batch port is justified by different platform storage costs and layouts; it expresses a portable application operation rather than a Cloudflare-only seal hint.
- Actual files changed: None yet.
- Validation run: None yet.
- Blockers: None.

### Task BPTM-2: Implement authoritative namespaced partial sets in both platform adapters

**Status:** Not started
**Depends on:** BPTM-1
**Documentation:** `src/plugins/README.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `src/kixx/hyperview/template-file-store-interface.js`

**Objective**

Make namespaced partial reads complete and cacheable on Cloudflare while preserving Node's inspectable filesystem layout and giving both adapters identical observable replacement and missing-set behavior.

**Scope**

- In: Implement `putPartials()` and revised `getPartials()` in the Cloudflare and Node template-file-store adapters; remove their `putPartial()` implementations; update adapter unit tests and mocks.
- Out: Publishing API parsing and validation, application transaction scripts, route changes, legacy data migration, cleanup of legacy KV keys, and E2E tests.

**Design and invariants**

- Cloudflare namespaced writes create one value at `{namespace}/partials.json`. The JSON object maps prefix-included logical keys to source strings, for example `{ "partials/nav.html": "<nav/>" }`.
- Cloudflare does not also write individual `{namespace}/partials/...` keys and does not list or delete legacy keys. Replacing the manifest replaces the logical set.
- Cloudflare namespaced reads call `kvStore.get(manifestKey, { type: 'json', cacheTtl })` once, using the existing configured namespaced TTL and default of 86400 seconds. They never fall back to `list()` when the manifest is absent.
- A missing or structurally invalid namespaced manifest is an unexpected invariant failure. `{}` is valid and maps to `[]`.
- Cloudflare un-namespaced reads retain the existing `list()` plus bulk `get()` implementation and shorter TTL behavior, including its current legacy limits; expanding that path is out of scope.
- Node writes individual files beneath `{root}/{namespace}/partials/`. On each successful batch it removes only that directory, recreates it, and writes the complete submitted set. Base templates, page templates, and other build data are untouched.
- Node creates an empty `partials/` directory for an empty batch. A missing namespaced directory is an invariant failure; a missing un-namespaced directory remains `[]`.
- Neither adapter promises rollback after a failed replacement or ordering between concurrent replacements.
- Both adapters assert the port-level input shape at their boundary and return prefix-included file references in submitted order.

**Expected touch points**

- `src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js` — add manifest encoding, single-get namespaced reads, required namespaced batch writes, and invariant checks while preserving the flat fallback.
- `test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js` — cover exact manifest key/value, one cached JSON read, configured TTL, empty manifest, missing/invalid manifest failures, replacement, return shape, and retained un-namespaced listing.
- `src/plugins/node-hyperview-template-file-store/lib/template-file-store.js` — replace the namespaced partial directory and distinguish missing namespaced from missing flat directories.
- `test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — cover complete replacement, omitted-file removal, nested files, empty sets, missing-set behavior, isolation from other template prefixes, and result ordering.

Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] A Cloudflare namespaced render loads all partial sources through one cacheable JSON `get()` and performs no `list()` or bulk read.
- [ ] Cloudflare stores only the manifest for new namespaced partial batches and ignores any legacy individual keys.
- [ ] Node stores individual partial files and removes files omitted by a later successful batch without touching other build content.
- [ ] Both adapters return `[]` for an explicitly empty set and fail for an unpublished namespaced set.
- [ ] Un-namespaced reads preserve the pre-change behavior on both adapters.
- [ ] Adapter tests prove the storage representations and shared observable contract.

**Validation**

- `node run-linter.js src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js src/plugins/node-hyperview-template-file-store/lib/template-file-store.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — validates both adapters and their tests.
- `node run-tests.js test/unit-tests/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.test.js test/unit-tests/plugins/node-hyperview-template-file-store/lib/template-file-store.test.js` — proves manifest and filesystem behavior.
- `rg -n "list\\(" src/plugins/cloudflare-hyperview-template-file-store/lib/template-file-store.js` — manually confirm that listing is reachable only from the un-namespaced fallback.

**Progress and handoff**

- Completed: Nothing yet.
- Current state: Not started.
- Remaining: Everything described above.
- Decisions and discoveries: The 25 MiB KV value cap is accepted. No runtime migration or backfill exists, so deployments using the new reader must publish a new partial set before becoming live.
- Actual files changed: None yet.
- Validation run: None yet.
- Blockers: None.

### Task BPTM-3: Replace the per-file partial Publishing API with complete-set JSON:API publication

**Status:** Not started
**Depends on:** BPTM-1
**Documentation:** `src/app/presentation/README.md`; `src/app/transaction-scripts/README.md`; `src/docs/server-error-handling.md`; `src/docs/code-style-guide.md`; `src/docs/code-documentation-guide.md`; `test/unit-tests/README.md`

**Objective**

Expose one authenticated, validated, idempotent collection `PUT` that publishes every partial for a staged build and remove every application path that publishes an individual partial.

**Scope**

- In: Add the batch Form, handler, and transaction script; register the exact optional-trailing-slash route; reuse template authorization; narrow the existing single-template workflow to base/page; remove the wildcard partial route and handler export; add and update unit tests.
- Out: Adapter storage details, new permissions, a build-finalization endpoint, a public API guide, deployment orchestration code, and E2E execution.

**Design and invariants**

- Route: `PUT /publishing-api/v1/templates/partials{/}`. It must be ordered so the exact collection route cannot be shadowed by broader template or catch-all routes.
- Authorization remains action `urn:kixx:publishing:template:put` on resource `urn:kixx:publishing:template`.
- Require `Content-Type: application/vnd.api+json` through the existing JSON:API helper.
- Require `Content-Length` before consuming the body. Missing uses `BadRequestError` with `httpStatusCode: 411` and code `ContentLengthRequired`; malformed or negative values are `400`; values above `25 * 1024 * 1024` bytes are `PayloadTooLargeError` (`413`). The endpoint trusts this authenticated client's declaration and does not recount buffered bytes.
- Request resource type is `PartialTemplateSet`. `data.id` is optional; when present it must equal `partials/<Kixx-Build-Id>` or produce the existing JSON:API conflict style.
- `attributes.partials` is required and must be an array. `[]` is a valid complete empty set. Unknown attributes and entry properties are ignored.
- Each entry requires `filepath` and `source`. Filepaths are relative to the partial prefix, are not trimmed, and are validated with the same safe-path rules as the retired wildcard route before being folded to lower case. Leading, trailing, and doubled slashes are rejected. A leading literal `partials/` is not stripped and therefore represents a nested relative path.
- Sources must be non-empty strings, are not trimmed, and are passed through after JSON decoding. Whitespace-only sources remain allowed under the existing non-empty-string rule.
- Validate the full batch before calling the transaction script. Detect duplicates after normalization and report all applicable field errors through `ValidationError`, using stable nested sources such as `partials[2].filepath`.
- A dedicated API-only Form owns payload normalization and field validation. A dedicated `publishing/put-partials.js` transaction script owns Build ID input/domain errors and delegates to `HyperviewService.putPartials()` once.
- Build ID rules match existing template writes: required, valid, non-reserved, and different from the current runtime Build ID. Sequential replacement while staged is allowed.
- Remove `partial` from the existing single-template kind set and remove its handler/export/route. Base and page behavior is unchanged.
- Success is `200 application/vnd.api+json` with type `PartialTemplateSet`, id `partials/<buildId>`, and attributes `{ buildId, partials: [{ filepath }, ...] }`. Paths are kind-relative, normalized, submitted-order references; sources and a redundant count are omitted.

**Expected touch points**

- `src/app/presentation/forms/templates/put-partials-form.js` — own JSON:API batch normalization, validation, duplicate detection, and serialization to service inputs.
- `src/app/presentation/request-handlers/publishing-api/put-partials.js` — enforce media type and declared size, parse the resource, validate optional identity, invoke the transaction script, and format the summary response.
- `src/app/transaction-scripts/publishing/put-partials.js` — enforce staged Build ID rules and translate unexpected service-write failures consistently with existing publishing scripts.
- `src/app/presentation/request-handlers/publishing-api/put-template.js` — remove the partial handler and retain only base/page single-file behavior.
- `src/app/transaction-scripts/publishing/put-template.js` — narrow supported kinds to base/page and remove single-partial delegation.
- `src/app/presentation/request-handlers/publishing-api/mod.js` — export the batch handler and remove the single-partial export.
- `src/routes/publishing-api-v1.js` — replace the partial wildcard target with the complete-set route and reuse `requireTemplatePermission`.
- `test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js` — cover shape validation, empty input, unknown fields, exact source preservation, path normalization/rejection, and normalized duplicates.
- `test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js` — cover media type, Content-Length statuses and cap, JSON:API type/id, authorization assumptions, handler delegation, and response shape.
- `test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js` — cover Build ID rules, one service call, empty sets, result mapping, and failure translation.
- Existing `put-template` handler and transaction-script unit tests — remove partial cases while proving base/page behavior remains unchanged.
- Route or authorization unit tests, if existing coverage requires updates — prove the new route retains the existing coarse template permission.

Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] The only partial publishing route accepts a complete JSON:API set at `/templates/partials` with an optional trailing slash.
- [ ] The handler rejects missing/malformed/oversized declared lengths before calling `request.json()` and uses the agreed 411/400/413 errors.
- [ ] The Form accepts empty sets, preserves sources, normalizes safe paths, rejects empty segments, and rejects post-normalization collisions without partial writes.
- [ ] Optional `data.id` is checked against `partials/<buildId>` and the success response uses that same identity with normalized source-free references.
- [ ] The batch transaction script and Hyperview service forbid writes to the live build and allow sequential staged replacements.
- [ ] No application route, handler, transaction script, or service retains single-partial publication.
- [ ] Base and page template publishing remains behaviorally unchanged.
- [ ] Unit tests cover all success and error branches described above.

**Validation**

- `node run-linter.js src/app/presentation/forms/templates/put-partials-form.js src/app/presentation/request-handlers/publishing-api/put-partials.js src/app/presentation/request-handlers/publishing-api/put-template.js src/app/transaction-scripts/publishing/put-partials.js src/app/transaction-scripts/publishing/put-template.js src/app/presentation/request-handlers/publishing-api/mod.js src/routes/publishing-api-v1.js test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js test/unit-tests/app/transaction-scripts/publishing/put-template.test.js` — validates the Publishing API implementation and unit tests.
- `node run-tests.js test/unit-tests/app/presentation/forms/templates/put-partials-form.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-partials.test.js test/unit-tests/app/presentation/request-handlers/publishing-api/put-template.test.js test/unit-tests/app/transaction-scripts/publishing/put-partials.test.js test/unit-tests/app/transaction-scripts/publishing/put-template.test.js` — proves payload, workflow, and retained base/page behavior.
- `rg -n "putPartialTemplate|putPartial\\(" src/app src/routes --glob '*.js'` — must return no retired application publishing path.

**Progress and handoff**

- Completed: Nothing yet.
- Current state: Not started.
- Remaining: Everything described above.
- Decisions and discoveries: Existing Forms ignore fields they do not own; the batch Form follows that convention. The project has no dedicated 411 error class, so the handler uses a scoped `BadRequestError` status override.
- Actual files changed: None yet.
- Validation run: None yet.
- Blockers: None.

### Task BPTM-4: Replace the partial Publishing API E2E contract and complete allowed verification

**Status:** Not started
**Depends on:** BPTM-2, BPTM-3
**Documentation:** `test/end-to-end/README.md`; `test/unit-tests/README.md`; root `README.md` development commands

**Objective**

Leave the repository's automated contracts describing the new batch endpoint, remove assertions for the retired endpoint, and verify all changed JavaScript through linting and unit tests without contacting or starting a deployment target.

**Scope**

- In: Rewrite/rename the two existing partial-template E2E files for the batch endpoint; perform a repository-wide stale-reference audit; run linting and the full unit suite; record that E2E execution was intentionally omitted.
- Out: Running E2E tests, starting the development server, calling a remote server, installing dependencies, adding a migration/backfill, or creating a new API documentation guide.

**Design and invariants**

- Replace the old `PUT /templates/partials/*filepath` happy-path and error-path tests rather than preserving them as compatibility coverage.
- E2E fixtures use the agreed JSON:API envelope, required `Content-Length`, Build ID header, and `PartialTemplateSet` response identity.
- Happy-path coverage includes multiple nested partials in one request, mixed-case normalization, a literal relative `partials/` prefix, sequential complete replacement, omitted-file removal as observable through subsequent rendering/publishing behavior where the existing E2E harness can prove it, and an empty set.
- Error coverage includes authentication/authorization, unsupported media type, missing/malformed/oversized declared length where the HTTP client can represent it safely, malformed JSON:API, wrong resource type, mismatched optional id, invalid entries, empty source, empty path segments, normalized duplicates, missing Build ID, and current-build conflict.
- Do not create a 25 MiB E2E body solely to exercise the cap. Cover impractical header/body combinations in unit tests when the E2E HTTP client enforces `Content-Length` consistency.
- E2E tests must be authored but not run, per explicit user direction.
- Final verification runs the linter for every changed JavaScript file and the complete unit suite. It also runs `git diff --check` and a stale-symbol search.

**Expected touch points**

- `test/end-to-end/020-publishing-api/put-partial-template.test.js` — replace or rename with batch happy-path coverage.
- `test/end-to-end/020-publishing-api/put-partial-template-errors.test.js` — replace or rename with batch error coverage.
- E2E publishing helpers under `test/end-to-end/test-helpers/`, if needed — centralize construction of the JSON:API request without changing unrelated endpoints.
- All files changed by BPTM-1 through BPTM-3 — include them in final linting and stale-reference review.

Treat this list as orientation, not permission to ignore other necessary files. Record the actual files changed in the handoff notes.

**Acceptance criteria**

- [ ] No E2E test asserts that an individual partial can be published.
- [ ] Batch E2E tests describe the agreed success response, replacement behavior, validation, authorization, and Build ID rules.
- [ ] E2E tests are not executed, and the final handoff explicitly records that omission as intentional rather than unverified by accident.
- [ ] No production or test reference to the retired `putPartial()`/`putPartialTemplate` contract remains, except historical implementation-plan text that is intentionally immutable.
- [ ] All changed JavaScript passes linting.
- [ ] The complete unit suite passes.
- [ ] No whitespace errors remain.

**Validation**

- `node run-linter.js <every changed JavaScript pathname>` — validates every source, unit-test, and E2E JavaScript file changed by the implementation.
- `node run-tests.js` — runs the complete unit suite and proves cross-module compatibility.
- `git diff --check` — detects whitespace errors in the complete patch.
- `rg -n "putPartialTemplate|putPartial\\(|templates/partials/\\*filepath" src test --glob '*.js'` — confirms removal of the retired code and executable test contract; review any intentional historical references separately.
- E2E execution: intentionally not run by explicit user instruction.

**Progress and handoff**

- Completed: Nothing yet.
- Current state: Not started.
- Remaining: Everything described above.
- Decisions and discoveries: Existing E2E coverage is split across happy-path and error-path partial-template files; both must be replaced, but the E2E suite must not be executed.
- Actual files changed: None yet.
- Validation run: None yet.
- Blockers: None.
